### PR TITLE
Glitre is again changing grid price

### DIFF
--- a/tibber/__init__.py
+++ b/tibber/__init__.py
@@ -863,9 +863,11 @@ class TibberHome:
         if grid_company and "glitre" in grid_company.lower():
             now = now.astimezone(pytz.timezone("Europe/Oslo"))
             if now.month >= 10 or now.month <= 3:
-                grid_price = 35.26 / 100
-            else:
+                grid_price = 47.39 / 100
+            elif now.month == 4:
                 grid_price = 41.51 / 100
+            else:
+                grid_price = 47.39 / 100
             if now.hour >= 22 or now.hour < 6:
                 grid_price -= 12 / 100
             attr["grid_price"] = round(grid_price, 3)


### PR DESCRIPTION
Glitre is again changing grid price. But not until May 1st.
As the price list says just now there is no difference on summer and winter prices this year. I am not sure if this is only a temporary adjustment, so therefore the logic isn't removed completely for winter/summer price.