### PR TITLE
Fix time zone issue

### DIFF
--- a/tibber/tibber_home.py
+++ b/tibber/tibber_home.py
@@ -360,7 +360,7 @@ class TibberHome:
     def current_price_data(self) -> Optional[tuple[float, str, dt.datetime]]:
         """Get current price."""
         price_time = (
-            dt.datetime.utcnow()
+            dt.datetime.now()
             .replace(minute=0, second=0, microsecond=0)
             .astimezone(self._tibber_control.time_zone)
         )


### PR DESCRIPTION
Avoid converting time to utc befaore searching api-data

Seems to fix https://github.com/Danielhiversen/pyTibber/issues/203 and https://github.com/home-assistant/core/issues/79701