### PR TITLE
Fixed crash if gridCompany exists but has the value of None

### DIFF
--- a/tibber/tibber_home.py
+++ b/tibber/tibber_home.py
@@ -524,8 +524,8 @@ class TibberHome:
         attr["off_peak_2"] = round(off_peak_2 / num2, 3) if num2 > 0 else 0
         if (
             "glitre"
-            in self.info["viewer"]["home"]["meteringPointData"]
-            .get("gridCompany", "")
+            in (self.info["viewer"]["home"]["meteringPointData"]
+                .get("gridCompany") or "")
             .lower()
         ):
             if now.month < 7:


### PR DESCRIPTION
A recent refactoring removed the test that checked if gridCompany had a value of None, this PR adds a test that returns empty string if gridCompany is either None or empty string or nonexisting