### PR TITLE
Remove code to avoid secondary exception in _start() to keep _start() alive during reconnect

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,20 +29,28 @@ pip3 install pyTibber
 ```python
 import tibber.const
 import tibber
+import asyncio
 
 access_token = tibber.const.DEMO_TOKEN
 tibber_connection = tibber.Tibber(access_token, user_agent="change_this")
-await tibber_connection.update_info()
-print(tibber_connection.name)
 
-home = tibber_connection.get_homes()[0]
-await home.update_info()
-print(home.address1)
+async def home_data():
+  home = tibber_connection.get_homes()[0]
+  await home.fetch_consumption_data()
+  await home.update_info()
+  print(home.address1)
 
-await home.update_price_info()
-print(home.current_price_info)
+  await home.update_price_info()
+  print(home.current_price_info)
 
-await tibber_connection.close_connection()
+async def start():
+  await tibber_connection.update_info()
+  print(tibber_connection.name)
+  await home_data()
+  await tibber_connection.close_connection()
+
+loop = asyncio.get_event_loop()
+loop.run_until_complete(start())
 ```
 
 
@@ -59,8 +67,8 @@ import tibber
 
 ACCESS_TOKEN = tibber.const.DEMO_TOKEN
 
-
 def _callback(pkg):
+    print(pkg)
     data = pkg.get("data")
     if data is None:
         return
@@ -70,10 +78,15 @@ def _callback(pkg):
 async def run():
     async with aiohttp.ClientSession() as session:
         tibber_connection = tibber.Tibber(ACCESS_TOKEN, websession=session, user_agent="change_this")
-        await tibber_connection.update_info()
+        await tibber_connection.update_info()        
     home = tibber_connection.get_homes()[0]
-    await home.rt_subscribe(_callback)
+    await home.rt_subscribe(_callback)    
 
+    while True:
+      await asyncio.sleep(10)
+
+loop = asyncio.get_event_loop()
+loop.run_until_complete(run())
 ```
 
 The library is used as part of Home Assistant.

--- a/README.md
+++ b/README.md
@@ -78,9 +78,9 @@ def _callback(pkg):
 async def run():
     async with aiohttp.ClientSession() as session:
         tibber_connection = tibber.Tibber(ACCESS_TOKEN, websession=session, user_agent="change_this")
-        await tibber_connection.update_info()        
+        await tibber_connection.update_info()
     home = tibber_connection.get_homes()[0]
-    await home.rt_subscribe(_callback)    
+    await home.rt_subscribe(_callback)
 
     while True:
       await asyncio.sleep(10)

--- a/tibber/tibber_home.py
+++ b/tibber/tibber_home.py
@@ -430,12 +430,12 @@ class TibberHome:
                     if self.rt_subscription_running:
                         _LOGGER.exception("Error in rt_subscribe")
                     await asyncio.sleep(10)
-                    await asyncio.gather(
-                        *[
-                            self.update_info(),
-                            self._tibber_control.update_info(),
-                        ]
-                    )
+#                    await asyncio.gather(
+#                        *[
+#                            self.update_info(),
+#                            self._tibber_control.update_info(),
+#                        ]
+#                    )
                     if not self.has_real_time_consumption:
                         _LOGGER.error("No real time device for %s", self.home_id)
                         return
@@ -474,7 +474,7 @@ class TibberHome:
                 cons_or_prod_str,
                 resolution,
                 _n_data,
-                "profit" if production else "cost",
+                "profit" if production else "totalCost cost",
                 cursor,
             )
             if not (data := await self._tibber_control.execute(query, timeout=30)):
@@ -483,11 +483,6 @@ class TibberHome:
             data = data["viewer"]["home"][cons_or_prod_str]
             if data is None:
                 continue
-            if not production:
-                for node in data["nodes"]:
-                    if "cost" in node:
-                        node["totalCost"] = node["cost"]
-
             res.extend(data["nodes"])
             n_data -= len(data["nodes"])
             if (

--- a/tibber/tibber_home.py
+++ b/tibber/tibber_home.py
@@ -429,16 +429,20 @@ class TibberHome:
                 except Exception:  # pylint: disable=broad-except
                     if self.rt_subscription_running:
                         _LOGGER.exception("Error in rt_subscribe")
-                    await asyncio.sleep(10)
-#                    await asyncio.gather(
-#                        *[
-#                            self.update_info(),
-#                            self._tibber_control.update_info(),
-#                        ]
-#                    )
+                    try:
+                        await asyncio.sleep(10)
+                        await asyncio.gather(
+                            *[
+                                self.update_info(),
+                                self._tibber_control.update_info(),
+                            ]
+                        )
+                    except Exception:
+                        await asyncio.sleep(10)
+
                     if not self.has_real_time_consumption:
                         _LOGGER.error("No real time device for %s", self.home_id)
-                        return
+                        continue
 
         await self._tibber_control.rt_connect()
         asyncio.create_task(_start())

--- a/tibber/tibber_home.py
+++ b/tibber/tibber_home.py
@@ -440,8 +440,8 @@ class TibberHome:
                         _LOGGER.error("No real time device for %s", self.home_id)
                         return
 
-        asyncio.create_task(_start())
         await self._tibber_control.rt_connect()
+        asyncio.create_task(_start())
 
     @property
     def rt_subscription_running(self) -> bool:


### PR DESCRIPTION
This is not really tested, so please evaluate this suggestion carefully before merging this pull request