### PR TITLE
Adjust gql dep to remove extras and set minimum version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,8 +12,9 @@ setup(
     install_requires=[
         "aiohttp>=3.0.6",
         "async_timeout>=1.4.0",
-        "gql[aiohttp,websockets]",
+        "gql>=3.0.0",
         "python-dateutil",
+        "websockets>=10.0"
     ],
     package_data={"tibber": ["py.typed"]},
     version=consts["__version__"],


### PR DESCRIPTION
Because of the websockets pin in gql to < 11.0 we end up with gql 0.5.0 with the new resolver. To fix this, remove the extras and specify the versions

Before
```
% pip3 install --upgrade . -c ~/home-assistant/homeassistant/package_constraints.txt
Processing /Users/bdraco/pyTibber
  Preparing metadata (setup.py) ... done
Requirement already satisfied: aiohttp>=3.0.6 in /opt/homebrew/lib/python3.11/site-packages (from pyTibber==0.27.1) (3.8.4)
Requirement already satisfied: async_timeout>=1.4.0 in /opt/homebrew/lib/python3.11/site-packages (from pyTibber==0.27.1) (4.0.2)
Requirement already satisfied: gql[aiohttp,websockets] in /opt/homebrew/lib/python3.11/site-packages (from pyTibber==0.27.1) (3.4.0)
Requirement already satisfied: python-dateutil in /opt/homebrew/lib/python3.11/site-packages (from pyTibber==0.27.1) (2.8.2)
Requirement already satisfied: attrs>=17.3.0 in /opt/homebrew/lib/python3.11/site-packages (from aiohttp>=3.0.6->pyTibber==0.27.1) (22.2.0)
Requirement already satisfied: charset-normalizer<4.0,>=2.0 in /opt/homebrew/lib/python3.11/site-packages (from aiohttp>=3.0.6->pyTibber==0.27.1) (3.1.0)
Requirement already satisfied: multidict<7.0,>=4.5 in /opt/homebrew/lib/python3.11/site-packages (from aiohttp>=3.0.6->pyTibber==0.27.1) (6.0.4)
Requirement already satisfied: yarl<2.0,>=1.0 in /opt/homebrew/lib/python3.11/site-packages (from aiohttp>=3.0.6->pyTibber==0.27.1) (1.9.2)
Requirement already satisfied: frozenlist>=1.1.1 in /opt/homebrew/lib/python3.11/site-packages (from aiohttp>=3.0.6->pyTibber==0.27.1) (1.3.3)
Requirement already satisfied: aiosignal>=1.1.2 in /opt/homebrew/lib/python3.11/site-packages (from aiohttp>=3.0.6->pyTibber==0.27.1) (1.3.1)
Requirement already satisfied: graphql-core<3.3,>=3.2 in /opt/homebrew/lib/python3.11/site-packages (from gql[aiohttp,websockets]->pyTibber==0.27.1) (3.2.3)
Requirement already satisfied: backoff<3.0,>=1.11.1 in /opt/homebrew/lib/python3.11/site-packages (from gql[aiohttp,websockets]->pyTibber==0.27.1) (2.2.1)
INFO: pip is looking at multiple versions of async-timeout to determine which version is compatible with other requirements. This could take a while.
Collecting async_timeout>=1.4.0
  Using cached async_timeout-4.0.2-py3-none-any.whl (5.8 kB)
INFO: pip is looking at multiple versions of aiohttp to determine which version is compatible with other requirements. This could take a while.
Collecting aiohttp>=3.0.6
  Using cached aiohttp-3.8.4-cp311-cp311-macosx_11_0_arm64.whl (332 kB)
INFO: pip is looking at multiple versions of <Python from Requires-Python> to determine which version is compatible with other requirements. This could take a while.
INFO: pip is looking at multiple versions of pytibber to determine which version is compatible with other requirements. This could take a while.
ERROR: Cannot install gql[aiohttp,websockets]==3.4.0 because these package versions have conflicting dependencies.

The conflict is caused by:
    gql[aiohttp,websockets] 3.4.0 depends on websockets<11 and >=10; python_version > "3.6" and extra == "websockets"
    The user requested (constraint) websockets>=11.0.1

To fix this you could try to:
1. loosen the range of package versions you've specified
2. remove package versions to allow pip attempt to solve the dependency conflict

ERROR: ResolutionImpossible: for help visit https://pip.pypa.io/en/latest/topics/dependency-resolution/#dealing-with-dependency-conflicts

[notice] A new release of pip is available: 23.0.1 -> 23.1
[notice] To update, run: python3.11 -m pip install --upgrade pip
````

After
```
% pip3 install --upgrade . -c ~/home-assistant/homeassistant/package_constraints.txt
Processing /Users/bdraco/pyTibber
  Preparing metadata (setup.py) ... done
Requirement already satisfied: aiohttp>=3.0.6 in /opt/homebrew/lib/python3.11/site-packages (from pyTibber==0.27.1) (3.8.4)
Requirement already satisfied: async_timeout>=1.4.0 in /opt/homebrew/lib/python3.11/site-packages (from pyTibber==0.27.1) (4.0.2)
Requirement already satisfied: gql>=3.0.0 in /opt/homebrew/lib/python3.11/site-packages (from pyTibber==0.27.1) (3.4.0)
Requirement already satisfied: python-dateutil in /opt/homebrew/lib/python3.11/site-packages (from pyTibber==0.27.1) (2.8.2)
Requirement already satisfied: websockets>=10.0 in /opt/homebrew/lib/python3.11/site-packages (from pyTibber==0.27.1) (11.0.2)
Requirement already satisfied: attrs>=17.3.0 in /opt/homebrew/lib/python3.11/site-packages (from aiohttp>=3.0.6->pyTibber==0.27.1) (22.2.0)
Requirement already satisfied: charset-normalizer<4.0,>=2.0 in /opt/homebrew/lib/python3.11/site-packages (from aiohttp>=3.0.6->pyTibber==0.27.1) (3.1.0)
Requirement already satisfied: multidict<7.0,>=4.5 in /opt/homebrew/lib/python3.11/site-packages (from aiohttp>=3.0.6->pyTibber==0.27.1) (6.0.4)
Requirement already satisfied: yarl<2.0,>=1.0 in /opt/homebrew/lib/python3.11/site-packages (from aiohttp>=3.0.6->pyTibber==0.27.1) (1.9.2)
Requirement already satisfied: frozenlist>=1.1.1 in /opt/homebrew/lib/python3.11/site-packages (from aiohttp>=3.0.6->pyTibber==0.27.1) (1.3.3)
Requirement already satisfied: aiosignal>=1.1.2 in /opt/homebrew/lib/python3.11/site-packages (from aiohttp>=3.0.6->pyTibber==0.27.1) (1.3.1)
Requirement already satisfied: graphql-core<3.3,>=3.2 in /opt/homebrew/lib/python3.11/site-packages (from gql>=3.0.0->pyTibber==0.27.1) (3.2.3)
Requirement already satisfied: backoff<3.0,>=1.11.1 in /opt/homebrew/lib/python3.11/site-packages (from gql>=3.0.0->pyTibber==0.27.1) (2.2.1)
Requirement already satisfied: six>=1.5 in /opt/homebrew/lib/python3.11/site-packages (from python-dateutil->pyTibber==0.27.1) (1.16.0)
Requirement already satisfied: idna>=2.0 in /opt/homebrew/lib/python3.11/site-packages (from yarl<2.0,>=1.0->aiohttp>=3.0.6->pyTibber==0.27.1) (3.4)
Building wheels for collected packages: pyTibber
  Building wheel for pyTibber (setup.py) ... done
  Created wheel for pyTibber: filename=pyTibber-0.27.1-py3-none-any.whl size=26027 sha256=838652c2377fa641194285696520e1c64d4df280af32ab674eadab4603220d97
  Stored in directory: /private/var/folders/v7/0sj93k_n0p56bpyk3vmf2z900000gn/T/pip-ephem-wheel-cache-fjxekwxu/wheels/1a/8c/dd/fd5dbf6ab657c0d8b6660d0fbde567eeb857222c3dd357c026
Successfully built pyTibber
Installing collected packages: pyTibber
  Attempting uninstall: pyTibber
    Found existing installation: pyTibber 0.27.1
    Uninstalling pyTibber-0.27.1:
      Successfully uninstalled pyTibber-0.27.1
Successfully installed pyTibber-0.27.1

[notice] A new release of pip is available: 23.0.1 -> 23.1
[notice] To update, run: python3.11 -m pip install --upgrade pip
```