### PR TITLE
Add the has_production check that was removed in PR 285

### DIFF
--- a/tibber/__init__.py
+++ b/tibber/__init__.py
@@ -214,7 +214,13 @@ class Tibber:
 
     async def fetch_production_data_active_homes(self) -> None:
         """Fetch production data for active homes."""
-        await asyncio.gather(*[tibber_home.fetch_production_data() for tibber_home in self.get_homes(only_active=True)])
+        await asyncio.gather(
+            *[
+                tibber_home.fetch_production_data()
+                for tibber_home in self.get_homes(only_active=True)
+                if tibber_home.has_production
+            ]
+        )
 
     async def rt_disconnect(self) -> None:
         """Stop subscription manager.


### PR DESCRIPTION
As requested by @MartinHjelmare: https://github.com/home-assistant/core/pull/124407#pullrequestreview-2254415904

This PR makes sure production data is only fetched when supported.

This was inadvertently removed here:
https://github.com/Danielhiversen/pyTibber/pull/285/files#diff-77c84b87c9a59562eefa1e142d347b64bbcaab889c944c198eb0a81f08255e72R211 