### PR TITLE
Fix NoneType comparison

### DIFF
--- a/tibber/home.py
+++ b/tibber/home.py
@@ -418,8 +418,9 @@ class TibberHome:
             if "lastMeterProduction" in live_data:
                 live_data["lastMeterProduction"] = max(0, live_data["lastMeterProduction"])
 
-            if live_data.get("powerProduction", 0) > 0 and live_data.get("power") is None:
-                live_data["power"] = 0
+            if power_production := live_data.get("powerProduction"):
+                if power_production > 0 and live_data.get("power") is None:
+                    live_data["power"] = 0
 
             if live_data.get("power", 0) > 0 and live_data.get("powerProduction") is None:
                 live_data["powerProduction"] = 0


### PR DESCRIPTION
Ref conversation in https://github.com/home-assistant/core/pull/124595

Running Home Assistant with `pyTibber==0.30.1` gives me an error:
```python
2024-08-27 12:53:36.477 ERROR (MainThread) [tibber.home] Error in rt_subscribe
Traceback (most recent call last):
  File "/home/vscode/.local/ha-venv/lib/python3.12/site-packages/tibber/home.py", line 460, in _start
    data = _add_extra_data(data)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/home/vscode/.local/ha-venv/lib/python3.12/site-packages/tibber/home.py", line 421, in _add_extra_data
    if live_data.get("powerProduction", 0) > 0 and live_data.get("power") is None:
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: '>' not supported between instances of 'NoneType' and 'int'
```

This happens because the `powerProduction` key in the extra data dict is `None`. Then the `.get(..., 0)` won't default to 0 because it's explicitly set to None and not missing.

This is the input I'm getting from the subscription.
```json
{
  "data": {
    "liveMeasurement": {
      "accumulatedConsumption": 12.458026,
      "accumulatedConsumptionLastHour": 0.018409,
      "accumulatedCost": 7.797286,
      "accumulatedProduction": 0.110517,
      "accumulatedProductionLastHour": 0.010517,
      "accumulatedReward": 0.050691,
      "averagePower": 1363.1,
      "currency": "NOK",
      "currentL1": null,
      "currentL2": null,
      "currentL3": null,
      "lastMeterConsumption": 29925.24,
      "lastMeterProduction": 3942.95,
      "maxPower": 4462,
      "minPower": 0,
      "power": 0,
      "powerFactor": null,
      "powerProduction": null,
      "powerReactive": null,
      "signalStrength": null,
      "timestamp": "2024-08-28T09:08:20.000+02:00",
      "voltagePhase1": null,
      "voltagePhase2": null,
      "voltagePhase3": null
    }
  }
}
```

We just need to explicitly check for None before comparing with 0.