### PR TITLE
Historic data by date

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,6 +85,7 @@ celerybeat-schedule
 # virtualenv
 .venv
 venv/
+venvs/
 ENV/
 
 # Spyder project settings
@@ -99,3 +100,6 @@ ENV/
 
 # mypy
 .mypy_cache/
+
+# IDE
+.idea/

--- a/test/test_tibber.py
+++ b/test/test_tibber.py
@@ -160,7 +160,7 @@ async def test_tibber_get_historic_data():
         home = homes[0]
         assert home is not None
 
-        historic_data = await home.get_historic_data_date(dt.datetime(2024, 1, 1), 5, RESOLUTION_DAILY)
+        historic_data = await home.get_historic_data_date(dt.datetime(2024, 1, 1, tzinfo=dt.UTC), 5, RESOLUTION_DAILY)
         assert len(historic_data) == 5
         assert historic_data[0]["from"] == "2024-01-01T00:00:00.000+01:00", "First day must be 2024-01-01"
         assert historic_data[4]["from"] == "2024-01-05T00:00:00.000+01:00", "Last day must be 2024-01-05"

--- a/test/test_tibber.py
+++ b/test/test_tibber.py
@@ -1,8 +1,8 @@
 """Tests for pyTibber."""
+import datetime as dt
 
 import aiohttp
 import pytest
-import datetime as dt
 
 import tibber
 from tibber.const import RESOLUTION_DAILY

--- a/test/test_tibber.py
+++ b/test/test_tibber.py
@@ -1,4 +1,5 @@
 """Tests for pyTibber."""
+
 import datetime as dt
 
 import aiohttp

--- a/test/test_tibber.py
+++ b/test/test_tibber.py
@@ -2,8 +2,10 @@
 
 import aiohttp
 import pytest
+import datetime as dt
 
 import tibber
+from tibber.const import RESOLUTION_DAILY
 from tibber.exceptions import FatalHttpExceptionError, InvalidLoginError
 
 
@@ -141,3 +143,24 @@ async def test_tibber_current_price_rank():
 
         assert isinstance(price_rank, int), "Price rank was unset"
         assert 1 <= price_rank <= 24, "Price rank is out of range"
+
+
+@pytest.mark.asyncio
+async def test_tibber_get_historic_data():
+    async with aiohttp.ClientSession() as session:
+        tibber_connection = tibber.Tibber(
+            websession=session,
+            user_agent="test",
+        )
+        await tibber_connection.update_info()
+
+        homes = tibber_connection.get_homes()
+        assert len(homes) == 1, "Expected 1 home, got '{}'".format(len(homes))
+
+        home = homes[0]
+        assert home is not None
+
+        historic_data = await home.get_historic_data_date(dt.datetime(2024, 1, 1), 5, RESOLUTION_DAILY)
+        assert len(historic_data) == 5
+        assert historic_data[0]["from"] == '2024-01-01T00:00:00.000+01:00', "First day must be 2024-01-01"
+        assert historic_data[4]["from"] == '2024-01-05T00:00:00.000+01:00', "Last day must be 2024-01-05"

--- a/test/test_tibber.py
+++ b/test/test_tibber.py
@@ -155,12 +155,12 @@ async def test_tibber_get_historic_data():
         await tibber_connection.update_info()
 
         homes = tibber_connection.get_homes()
-        assert len(homes) == 1, "Expected 1 home, got '{}'".format(len(homes))
+        assert len(homes) == 1, f"Expected 1 home, got '{len(homes)}'"
 
         home = homes[0]
         assert home is not None
 
         historic_data = await home.get_historic_data_date(dt.datetime(2024, 1, 1), 5, RESOLUTION_DAILY)
         assert len(historic_data) == 5
-        assert historic_data[0]["from"] == '2024-01-01T00:00:00.000+01:00', "First day must be 2024-01-01"
-        assert historic_data[4]["from"] == '2024-01-05T00:00:00.000+01:00', "Last day must be 2024-01-05"
+        assert historic_data[0]["from"] == "2024-01-01T00:00:00.000+01:00", "First day must be 2024-01-01"
+        assert historic_data[4]["from"] == "2024-01-05T00:00:00.000+01:00", "Last day must be 2024-01-05"

--- a/tibber/gql_queries.py
+++ b/tibber/gql_queries.py
@@ -20,6 +20,26 @@ HISTORIC_DATA = """
                   }}
                 }}
           """
+HISTORIC_DATA_DATE = """
+                    {{
+                      viewer {{
+                        home(id: "{0}") {{
+                          {1}(resolution: {2}, first: {3}, after: "{4}") {{
+                            nodes {{
+                              from
+                              to
+                              unitPrice
+                              unitPriceVAT
+                              consumption
+                              consumptionUnit
+                              cost
+                              currency
+                            }}
+                          }}
+                        }}
+                      }}
+                    }}
+                    """
 HISTORIC_PRICE = """
                 {{
                   viewer {{

--- a/tibber/home.py
+++ b/tibber/home.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import base64
 import contextlib
 import datetime as dt
 import logging
@@ -13,6 +14,7 @@ from gql import gql
 from .const import RESOLUTION_HOURLY
 from .gql_queries import (
     HISTORIC_DATA,
+    HISTORIC_DATA_DATE,
     HISTORIC_PRICE,
     LIVE_SUBSCRIBE,
     PRICE_INFO,
@@ -542,6 +544,47 @@ class TibberHome:
         if data is None:
             return []
         return data["nodes"]
+
+    async def get_historic_data_date(
+        self, date_from: dt.datetime, n_data: int, resolution: str = RESOLUTION_HOURLY,
+        production: bool = False
+    ) -> list[dict[str, Any]]:
+        """Get historic data.
+        :param date_from: The start-date to get the data from
+        :param n_data: The number of nodes to get from history. e.g. 5 would give 5 nodes
+            and resolution = hourly would give the 5 last hours of historic data.
+            If 0 the set month-days will be calculated to the end of the month.
+        :param resolution: The resolution of the data. Can be HOURLY,
+            DAILY, WEEKLY, MONTHLY or ANNUAL
+        :param production: True to get production data instead of consumption
+        """
+
+        yesterday = date_from - dt.timedelta(days=1)
+        date_from_base64 = base64.b64encode(yesterday.strftime("%Y-%m-%d").encode()).decode("utf-8")
+
+        if n_data == 0:
+            # Calculate the number of days to the end of the month from the given date
+            n_data = (date_from.replace(day=1, month=date_from.month + 1) - date_from).days
+
+        cons_or_prod_str = "production" if production else "consumption"
+        query = HISTORIC_DATA_DATE.format(
+            self.home_id,
+            cons_or_prod_str,
+            resolution,
+            n_data,
+            date_from_base64
+        )
+
+        if not (data := await self._tibber_control.execute(query, timeout=30)):
+            # _LOGGER.error("Could not get the data.")
+            return []
+
+        data = data["viewer"]["home"][cons_or_prod_str]
+
+        if data is None:
+            return []
+
+        return data['nodes']
 
     async def get_historic_price_data(
         self,

--- a/tibber/home.py
+++ b/tibber/home.py
@@ -550,7 +550,7 @@ class TibberHome:
         date_from: dt.datetime,
         n_data: int,
         resolution: str = RESOLUTION_HOURLY,
-        production: bool = False
+        production: bool = False,
     ) -> list[dict[str, Any]]:
         """Get historic data.
         :param date_from: The start-date to get the data from

--- a/tibber/home.py
+++ b/tibber/home.py
@@ -546,7 +546,10 @@ class TibberHome:
         return data["nodes"]
 
     async def get_historic_data_date(
-        self, date_from: dt.datetime, n_data: int, resolution: str = RESOLUTION_HOURLY,
+        self,
+        date_from: dt.datetime,
+        n_data: int,
+        resolution: str = RESOLUTION_HOURLY,
         production: bool = False
     ) -> list[dict[str, Any]]:
         """Get historic data.
@@ -572,7 +575,7 @@ class TibberHome:
             cons_or_prod_str,
             resolution,
             n_data,
-            date_from_base64
+            date_from_base64,
         )
 
         if not (data := await self._tibber_control.execute(query, timeout=30)):
@@ -584,7 +587,7 @@ class TibberHome:
         if data is None:
             return []
 
-        return data['nodes']
+        return data["nodes"]
 
     async def get_historic_price_data(
         self,

--- a/tibber/home.py
+++ b/tibber/home.py
@@ -576,7 +576,7 @@ class TibberHome:
         )
 
         if not (data := await self._tibber_control.execute(query, timeout=30)):
-            # _LOGGER.error("Could not get the data.")
+            _LOGGER.error("Could not get the data.")
             return []
 
         data = data["viewer"]["home"][cons_or_prod_str]


### PR DESCRIPTION
This is my first real open source contribution, so sorry for any mistakes here ^^" (open for critique).

Purpose of the `get_historic_data_date` is to actually get data for a month without filtering through obscure "number of results".  

I also added a test for the new function.

Examples:
```python
first_day_of_month = datetime.now().replace(day=1)
data = await home.get_historic_data_date(first_day_of_month, 0, const.RESOLUTION_DAILY)
```

```python
first_day_of_month = datetime(2024, 8, 1)
data = await home.get_historic_data_date(first_day_of_month, 0, const.RESOLUTION_DAILY)
```

Note 1:  
The `Tibber.home.get_historic_data_date` resolution parameter could be hard set to daily, but I wanted to keep the current function styles.

Note 2:  
The `HISTORIC_DATA_DATE` need some of the other parameters for power generation.

Note 3:  
The query field `totalCost` is deprecated.  
Warning from the Api Explorer: `The field Consumption.totalCost is deprecated. use cost instead.`

Note 4:  
At first I created a monkeypatch and thought I could also contribute this to the main project, it may help someone in the future.
