### PR TITLE
Fix issue with querying production

### DIFF
--- a/tibber/gql_queries.py
+++ b/tibber/gql_queries.py
@@ -30,10 +30,8 @@ HISTORIC_DATA_DATE = """
                               to
                               unitPrice
                               unitPriceVAT
-                              consumption
-                              consumptionUnit
-                              cost
                               currency
+                              {5}
                             }}
                           }}
                         }}

--- a/tibber/home.py
+++ b/tibber/home.py
@@ -576,6 +576,7 @@ class TibberHome:
             resolution,
             n_data,
             date_from_base64,
+            "profit production productionUnit" if production else "cost consumption consumptionUnit",
         )
 
         if not (data := await self._tibber_control.execute(query, timeout=30)):


### PR DESCRIPTION
The HISTORIC_DATA_DATE query has fields that are only availble in consumption node. That makes the get_historic_data_date call fail if production=True. Fix by supporting dynamic fields in query and set accordingly depending on production parameter.