### PR TITLE
Add logging tests and adjust websocket logging level in Tibber integration

### DIFF
--- a/test/test_tibber.py
+++ b/test/test_tibber.py
@@ -170,7 +170,7 @@ async def test_tibber_get_historic_data():
 
 
 @pytest.mark.asyncio
-async def test_logging_tibber_get_historic_data(caplog: pytest.LogCaptureFixture):
+async def test_logging_rt_subscribe(caplog: pytest.LogCaptureFixture) -> None:
     caplog.set_level(logging.INFO)
     async with aiohttp.ClientSession() as session:
         tibber_connection = tibber.Tibber(
@@ -189,9 +189,5 @@ async def test_logging_tibber_get_historic_data(caplog: pytest.LogCaptureFixture
         await tibber_connection.rt_disconnect()
         await asyncio.sleep(10)
 
-    assert (
-        "gql.transport.websockets:websockets_base.py:240" not in caplog.text
-    ), "should not show on info logging level"
-    assert (
-        "gql.transport.websockets:websockets_base.py:218" not in caplog.text
-    ), "should not show on info logging level"
+    assert "gql.transport.websockets:websockets_base.py:240" not in caplog.text, "should not show on info logging level"
+    assert "gql.transport.websockets:websockets_base.py:218" not in caplog.text, "should not show on info logging level"

--- a/test/test_tibber.py
+++ b/test/test_tibber.py
@@ -1,10 +1,10 @@
 """Tests for pyTibber."""
 
-import datetime as dt
 import asyncio
+import datetime as dt
+import logging
 
 import aiohttp
-import logging
 import pytest
 
 import tibber
@@ -170,7 +170,7 @@ async def test_tibber_get_historic_data():
 
 
 @pytest.mark.asyncio
-async def test_logging_tibber_get_historic_data(caplog):
+async def test_logging_tibber_get_historic_data(caplog: pytest.LogCaptureFixture):
     caplog.set_level(logging.INFO)
     async with aiohttp.ClientSession() as session:
         tibber_connection = tibber.Tibber(
@@ -180,9 +180,9 @@ async def test_logging_tibber_get_historic_data(caplog):
         await tibber_connection.update_info()
         home = tibber_connection.get_homes()[0]
 
-        def _callback(pkg):
+        def _callback(_: dict) -> None:
             return None
-        
+
         await home.rt_subscribe(_callback)
         await asyncio.sleep(1)
         home.rt_unsubscribe()

--- a/tibber/realtime.py
+++ b/tibber/realtime.py
@@ -8,6 +8,7 @@ from ssl import SSLContext
 from typing import Any
 
 from gql import Client
+from gql.transport.websockets import log as websockets_logger
 
 from .exceptions import SubscriptionEndpointMissingError
 from .home import TibberHome
@@ -16,6 +17,8 @@ from .websocket_transport import TibberWebsocketsTransport
 LOCK_CONNECT = asyncio.Lock()
 
 _LOGGER = logging.getLogger(__name__)
+
+websockets_logger.setLevel(logging.WARNING)
 
 
 class TibberRT:


### PR DESCRIPTION
The test is flaky since it seems like all tests actually connects to tibber for the testing. I never written a mockup of a ws interface so i didn't really know how to address this.