### PR TITLE
Support active Tibber subscription that is about to end

### DIFF
--- a/tibber/home.py
+++ b/tibber/home.py
@@ -318,6 +318,7 @@ class TibberHome:
             "awaiting market",
             "awaiting time restriction",
             "awaiting termination",
+            "ended",
         ]
 
     @property


### PR DESCRIPTION
Hi,

I terminated my Tibber subscription for end of January. Right now, my subscription is active though. The API shows this as an `ended` status:

Request
```
{
  viewer {
    homes {
      currentSubscription {
        status
      }
    }
  }
}
```

Response:
```
{
  "data": {
    "viewer": {
      "homes": [
        {
          "currentSubscription": {
            "status": "ended"
          }
        }
      ]
    }
  }
}
```

I'm not sure what happens at the actual termination date. That is, what value will be given as `status`.