### PR TITLE
Adjust GraphQL Authentication Error Handling to API changes from 2025-01-03 and Enhance Logging 

### DIFF
--- a/.github/workflows/code_checker.yml
+++ b/.github/workflows/code_checker.yml
@@ -14,6 +14,7 @@ jobs:
         python-version:
           - "3.11"
           - "3.12"
+          - "3.13"
     env:
       SRC_FOLDER: tibber
     steps:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
     hooks:
       - id: trailing-whitespace
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.6.2
+    rev: v0.11.0
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix, --config, pyproject.toml]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
     rev: v0.6.2
     hooks:
       - id: ruff
-        args: [--fix, --exit-non-zero-on-fix]
+        args: [--fix, --exit-non-zero-on-fix, --config, pyproject.toml]
       - id: ruff-format
   - repo: local
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ strict_optional = false
 
 [tool.ruff]
 line-length = 120
-target-version = "py311"
+target-version = "py313"
 
 [tool.ruff.lint]
 ignore = ["D", "EM", "FBT", "PLR0913", "C901", "S101", "TRY"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,3 +22,5 @@ known-first-party = ["tibber", "test"]
   "S101",
   "S106",
 ]
+[tool.pytest.ini_options]
+asyncio_default_fixture_loop_scope = "function"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,11 +16,8 @@ known-first-party = ["tibber", "test"]
 
 [tool.ruff.lint.per-file-ignores]
 "setup.py" = ["D100"]
-"test/**/*" = [
-  "ANN201",
-  "PLR2004",
-  "S101",
-  "S106",
-]
+"test/**/*" = ["ANN201", "PLR2004", "S101", "S106"]
+
+
 [tool.pytest.ini_options]
 asyncio_default_fixture_loop_scope = "function"

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,9 @@
 from pathlib import Path
+from typing import Any
 
 from setuptools import setup
 
-consts = {}
+consts: dict[str, Any] = {}
 exec((Path("tibber") / "const.py").read_text(encoding="utf-8"), consts)  # noqa: S102
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,11 @@ exec((Path("tibber") / "const.py").read_text(encoding="utf-8"), consts)  # noqa:
 setup(
     name="pyTibber",
     packages=["tibber"],
-    install_requires=["aiohttp>=3.0.6", "gql>=3.0.0", "websockets>=10.0"],
+    install_requires=[
+        "aiohttp>=3.11.13",
+        "gql[aiohttp,websockets]>=3.5.0",
+        "websockets>=11.0",
+    ],
     package_data={"tibber": ["py.typed"]},
     version=consts["__version__"],
     description="A python3 library to communicate with Tibber",

--- a/test/test_tibber.py
+++ b/test/test_tibber.py
@@ -9,7 +9,7 @@ import pytest
 
 import tibber
 from tibber.const import RESOLUTION_DAILY
-from tibber.exceptions import FatalHttpExceptionError, InvalidLoginError
+from tibber.exceptions import FatalHttpExceptionError, InvalidLoginError, NotForDemoUserError
 
 
 @pytest.mark.asyncio

--- a/test/test_tibber.py
+++ b/test/test_tibber.py
@@ -13,7 +13,7 @@ from tibber.exceptions import FatalHttpExceptionError, InvalidLoginError, NotFor
 
 
 @pytest.mark.asyncio
-async def test_tibber_no_session():
+async def test_tibber_no_session() -> None:
     tibber_connection = tibber.Tibber(
         user_agent="test",
     )
@@ -23,7 +23,7 @@ async def test_tibber_no_session():
 
 
 @pytest.mark.asyncio
-async def test_tibber():
+async def test_tibber() -> None:
     async with aiohttp.ClientSession() as session:
         tibber_connection = tibber.Tibber(
             websession=session,
@@ -52,7 +52,9 @@ async def test_tibber():
                 assert home.current_price_info == {}
 
                 await home.update_current_price_info()
+                assert home.current_price_total is not None
                 assert home.current_price_total > 0
+
                 assert isinstance(home.current_price_info.get("energy"), float | int)
                 assert isinstance(home.current_price_info.get("startsAt"), str)
                 assert isinstance(home.current_price_info.get("tax"), float | int)
@@ -75,7 +77,7 @@ async def test_tibber():
 
 
 @pytest.mark.asyncio
-async def test_tibber_invalid_token():
+async def test_tibber_invalid_token() -> None:
     async with aiohttp.ClientSession() as session:
         tibber_connection = tibber.Tibber(
             access_token="INVALID_TOKEN",
@@ -89,7 +91,7 @@ async def test_tibber_invalid_token():
 
 
 @pytest.mark.asyncio
-async def test_tibber_invalid_query():
+async def test_tibber_invalid_query() -> None:
     async with aiohttp.ClientSession() as session:
         tibber_connection = tibber.Tibber(
             websession=session,
@@ -104,7 +106,7 @@ async def test_tibber_invalid_query():
 
 
 @pytest.mark.asyncio
-async def test_tibber_notification():
+async def test_tibber_notification() -> None:
     async with aiohttp.ClientSession() as session:
         tibber_connection = tibber.Tibber(
             websession=session,
@@ -112,7 +114,8 @@ async def test_tibber_notification():
         )
 
         with pytest.raises(NotForDemoUserError, match="operation not allowed for demo user"):
-            await tibber_connection.send_notification("Test tittle", "message")
+            await tibber_connection.send_notification("Test title", "message")
+
 
 # ----------------------------------------------------------------------------------
 #                Comments on testing tibber_notification:
@@ -131,9 +134,8 @@ async def test_tibber_notification():
 # ----------------------------------------------------------------------------------
 
 
-
 @pytest.mark.asyncio
-async def test_tibber_token():
+async def test_tibber_token() -> None:
     async with aiohttp.ClientSession() as session:
         tibber_connection = tibber.Tibber(
             access_token="d11a43897efa4cf478afd659d6c8b7117da9e33b38232fd454b0e9f28af98012",
@@ -148,7 +150,7 @@ async def test_tibber_token():
 
 
 @pytest.mark.asyncio
-async def test_tibber_current_price_rank():
+async def test_tibber_current_price_rank() -> None:
     async with aiohttp.ClientSession() as session:
         tibber_connection = tibber.Tibber(
             websession=session,
@@ -167,7 +169,7 @@ async def test_tibber_current_price_rank():
 
 
 @pytest.mark.asyncio
-async def test_tibber_get_historic_data():
+async def test_tibber_get_historic_data() -> None:
     async with aiohttp.ClientSession() as session:
         tibber_connection = tibber.Tibber(
             websession=session,

--- a/test/test_tibber.py
+++ b/test/test_tibber.py
@@ -110,8 +110,26 @@ async def test_tibber_notification():
             websession=session,
             user_agent="test",
         )
-        await tibber_connection.update_info()
-        assert not await tibber_connection.send_notification("Test tittle", "message")
+
+        with pytest.raises(NotForDemoUserError, match="operation not allowed for demo user"):
+            await tibber_connection.send_notification("Test tittle", "message")
+
+# ----------------------------------------------------------------------------------
+#                Comments on testing tibber_notification:
+# ----------------------------------------------------------------------------------
+# - Current test only covers the case where the user is a demo user and the operation is not allowed.
+#   --> Still, it is a good test to have for tracking changes in api behavior.
+# ----------------------------------------------------------------------------------
+
+# ----------------------------------------------------------------------------------
+#                   Proposal for additional test cases:
+# ----------------------------------------------------------------------------------
+# - having three different api token types: demo, demo_always_success, demo_always_fail
+# --> demo: current behavior
+# --> demo_always_success: always returns success
+# --> demo_always_fail: always returns fail
+# ----------------------------------------------------------------------------------
+
 
 
 @pytest.mark.asyncio

--- a/test/test_tibber.py
+++ b/test/test_tibber.py
@@ -82,7 +82,7 @@ async def test_tibber_invalid_token():
             websession=session,
             user_agent="test",
         )
-        with pytest.raises(InvalidLoginError, match="Context creation failed: invalid token"):
+        with pytest.raises(InvalidLoginError, match="No valid access token in request"):
             await tibber_connection.update_info()
         assert not tibber_connection.name
         assert tibber_connection.get_homes() == []

--- a/tibber/__init__.py
+++ b/tibber/__init__.py
@@ -98,7 +98,7 @@ class Tibber:
         timeout_val = timeout or self.timeout
         payload = {"query": document, "variables": variable_values or {}}
         headers = {
-            "Authorization": f"Bearer { self._access_token }",
+            "Authorization": f"Bearer {self._access_token}",
             aiohttp.hdrs.USER_AGENT: self._user_agent,
         }
 
@@ -199,9 +199,7 @@ class Tibber:
             title,
             message,
         )
-        if not (
-            res := await self.execute(push_notification_query)
-        ):
+        if not (res := await self.execute(push_notification_query)):
             return False
         notification = res.get("sendPushNotification", {})
         successful = notification.get("successful", False)

--- a/tibber/const.py
+++ b/tibber/const.py
@@ -7,7 +7,7 @@ __version__ = "0.30.8"
 
 API_ENDPOINT: Final = "https://api.tibber.com/v1-beta/gql"
 DEFAULT_TIMEOUT: Final = 10
-DEMO_TOKEN: Final = "5K4MVS-OjfWhK_4yrjOlFe1F6kJXPVf7eQYggo8ebAE"
+DEMO_TOKEN: Final = "5K4MVS-OjfWhK_4yrjOlFe1F6kJXPVf7eQYggo8ebAE" # noqa: S105
 
 RESOLUTION_HOURLY: Final = "HOURLY"
 RESOLUTION_DAILY: Final = "DAILY"

--- a/tibber/const.py
+++ b/tibber/const.py
@@ -7,7 +7,7 @@ __version__ = "0.30.8"
 
 API_ENDPOINT: Final = "https://api.tibber.com/v1-beta/gql"
 DEFAULT_TIMEOUT: Final = 10
-DEMO_TOKEN: Final = "5K4MVS-OjfWhK_4yrjOlFe1F6kJXPVf7eQYggo8ebAE" # noqa: S105
+DEMO_TOKEN: Final = "5K4MVS-OjfWhK_4yrjOlFe1F6kJXPVf7eQYggo8ebAE"  # noqa: S105
 
 RESOLUTION_HOURLY: Final = "HOURLY"
 RESOLUTION_DAILY: Final = "DAILY"

--- a/tibber/exceptions.py
+++ b/tibber/exceptions.py
@@ -41,3 +41,6 @@ class RetryableHttpExceptionError(HttpExceptionError):
 
 class InvalidLoginError(FatalHttpExceptionError):
     """Invalid login exception."""
+
+class NotForDemoUserError(FatalHttpExceptionError):
+    """Exception raised when trying to use a feature not available for demo users"""

--- a/tibber/exceptions.py
+++ b/tibber/exceptions.py
@@ -42,5 +42,6 @@ class RetryableHttpExceptionError(HttpExceptionError):
 class InvalidLoginError(FatalHttpExceptionError):
     """Invalid login exception."""
 
+
 class NotForDemoUserError(FatalHttpExceptionError):
     """Exception raised when trying to use a feature not available for demo users"""

--- a/tibber/helper/wrapper.py
+++ b/tibber/helper/wrapper.py
@@ -1,0 +1,49 @@
+import inspect
+import logging
+from collections.abc import Awaitable, Callable
+from functools import wraps
+from typing import ParamSpec, TypeVar
+
+_LOGGER = logging.getLogger(__name__)
+
+P = ParamSpec("P")
+R = TypeVar("R")
+
+def log_request_query_types(func: Callable[P, Awaitable[R]]) -> Callable[P, Awaitable[R]]:
+    """Decorator to log the name of the `document` variable."""
+
+    @wraps(func)
+    async def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
+        # Get the frame of the caller
+        frame = inspect.currentframe().f_back
+        if not frame:
+            _LOGGER.warning("Could not get caller's frame")
+            return await func(*args, **kwargs)
+
+        frame_info = inspect.getframeinfo(frame)
+
+        # Get all local variables in the caller's scope
+        local_vars = frame.f_locals
+
+        # Find the variable name that matches the value passed as `document`
+        document_value = kwargs.get("document")
+
+        # Assuming the second argument is `document`
+        if document_value is None and len(args) > 1:
+            document_value = args[1]
+
+        variable_name = None
+        for var_name, var_value in local_vars.items():
+            if var_value == document_value:
+                variable_name = var_name
+                break
+
+        if variable_name:
+            _LOGGER.debug(
+                "sending request with: %s in %s", variable_name, frame_info.function,
+            )
+
+        # Execute original function
+        return await func(*args, **kwargs)
+
+    return wrapper

--- a/tibber/helper/wrapper.py
+++ b/tibber/helper/wrapper.py
@@ -9,21 +9,27 @@ _LOGGER = logging.getLogger(__name__)
 P = ParamSpec("P")
 R = TypeVar("R")
 
+
 def log_request_query_types(func: Callable[P, Awaitable[R]]) -> Callable[P, Awaitable[R]]:
     """Decorator to log the name of the `document` variable."""
 
     @wraps(func)
     async def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
         # Get the frame of the caller
-        frame = inspect.currentframe().f_back
-        if not frame:
+        current_frame = inspect.currentframe()
+        if current_frame is None:
+            _LOGGER.warning("Could not retrieve the current frame")
+            return await func(*args, **kwargs)
+
+        caller_frame = current_frame.f_back
+        if caller_frame is None:
             _LOGGER.warning("Could not get caller's frame")
             return await func(*args, **kwargs)
 
-        frame_info = inspect.getframeinfo(frame)
+        frame_info = inspect.getframeinfo(caller_frame)
 
         # Get all local variables in the caller's scope
-        local_vars = frame.f_locals
+        local_vars = caller_frame.f_locals
 
         # Find the variable name that matches the value passed as `document`
         document_value = kwargs.get("document")
@@ -40,7 +46,9 @@ def log_request_query_types(func: Callable[P, Awaitable[R]]) -> Callable[P, Awai
 
         if variable_name:
             _LOGGER.debug(
-                "sending request with: %s in %s", variable_name, frame_info.function,
+                "sending request with: %s in %s",
+                variable_name,
+                frame_info.function,
             )
 
         # Execute original function

--- a/tibber/response_handler.py
+++ b/tibber/response_handler.py
@@ -40,19 +40,37 @@ async def extract_response_data(response: ClientResponse) -> dict[Any, Any]:
             API_ERR_CODE_UNKNOWN,
         )
 
-    result = await response.json()
+    result : dict[Any, Any] = await response.json()
+
+    # From API Changelog 2025-01-03:
+    # As part of a major framework update, the API will now no longer return an HTTP status code 400
+    # on authentication errors (missing or invalid tokens). Instead, it will follow the convention of
+    # several GraphQL servers and return a 200 status code, and the errors array will contain an
+    # object whose extensions.code property will have the value UNAUTHENTICATED set.
 
     if response.status == HTTPStatus.OK:
-        return result
+        errors : list[dict[str, Any]] = result.get("errors")
+        if not errors:
+            return result
+
+        error_code, error_message = extract_error_details(errors, str(response.content))
+        if error_code == "UNAUTHENTICATED":
+            _LOGGER.error("InvalidLoginError %s %s", error_message, error_code)
+            raise InvalidLoginError(response.status, error_message, error_code)
+
+        if (error_code == "INTERNAL_SERVER_ERROR") & ("demo user" in error_message):
+            _LOGGER.error("NotForDemoUserError %s %s", error_message, error_code)
+            raise NotForDemoUserError(response.status, error_message, error_code)
 
     if response.status in HTTP_CODES_RETRIABLE:
         error_code, error_message = extract_error_details(result.get("errors", []), str(response.content))
-
+        _LOGGER.error("RetryableHttpExceptionError %s %s", error_message, error_code)
         raise RetryableHttpExceptionError(response.status, message=error_message, extension_code=error_code)
 
     if response.status in HTTP_CODES_FATAL:
         error_code, error_message = extract_error_details(result.get("errors", []), "request failed")
         if error_code == API_ERR_CODE_UNAUTH:
+            _LOGGER.error("InvalidLoginError %s %s", error_message, error_code)
             raise InvalidLoginError(response.status, error_message, error_code)
 
         _LOGGER.error("FatalHttpExceptionError %s %s", error_message, error_code)

--- a/tibber/response_handler.py
+++ b/tibber/response_handler.py
@@ -15,6 +15,7 @@ from .const import (
 from .exceptions import (
     FatalHttpExceptionError,
     InvalidLoginError,
+    NotForDemoUserError,
     RetryableHttpExceptionError,
 )
 

--- a/tibber/response_handler.py
+++ b/tibber/response_handler.py
@@ -28,8 +28,8 @@ def extract_error_details(errors: list[dict], default_message: str) -> tuple[str
 
     if not errors:
         return API_ERR_CODE_UNKNOWN, default_message
-    error : dict[str, Any] = errors[0]
-    extensions : dict[str, Any] = error.get("extensions", {})
+    error: dict[str, Any] = errors[0]
+    extensions: dict[str, Any] = error.get("extensions", {})
     return (
         extensions.get("code", API_ERR_CODE_UNKNOWN),
         error.get("message", default_message),
@@ -49,7 +49,7 @@ async def extract_response_data(response: ClientResponse) -> dict[str, Any]:
         )
 
     try:
-        result : dict[str, Any] = await response.json()
+        result: dict[str, Any] = await response.json()
     except JSONDecodeError as err:
         raise FatalHttpExceptionError(
             response.status,
@@ -65,7 +65,7 @@ async def extract_response_data(response: ClientResponse) -> dict[str, Any]:
         )
 
     # precache errors
-    errors : list[dict[str, Any]] = result.get("errors", [])
+    errors: list[dict[str, Any]] = result.get("errors", [])
 
     # From API Changelog 2025-01-03:
     # As part of a major framework update, the API will now no longer return an HTTP status code 400
@@ -92,7 +92,7 @@ async def extract_response_data(response: ClientResponse) -> dict[str, Any]:
         raise RetryableHttpExceptionError(response.status, message=error_message, extension_code=error_code)
 
     if response.status in HTTP_CODES_FATAL:
-        error_code, error_message = extract_error_details(errors, default_message = "request failed")
+        error_code, error_message = extract_error_details(errors, default_message="request failed")
         if error_code == API_ERR_CODE_UNAUTH:
             _LOGGER.error("InvalidLoginError %s %s", error_message, error_code)
             raise InvalidLoginError(response.status, error_message, error_code)
@@ -100,7 +100,7 @@ async def extract_response_data(response: ClientResponse) -> dict[str, Any]:
         _LOGGER.error("FatalHttpExceptionError %s %s", error_message, error_code)
         raise FatalHttpExceptionError(response.status, error_message, error_code)
 
-    error_code, error_message = extract_error_details(errors, default_message = "N/A")
+    error_code, error_message = extract_error_details(errors, default_message="N/A")
 
     # if reached here the HTTP response code is not currently handled
     _LOGGER.error("FatalHttpExceptionError %s %s", error_message, error_code)


### PR DESCRIPTION
**What this PR does:**
- Updates the response_handler to correctly handle authentication errors according to the recent API changes, which now return a `200` HTTP status with detailed error messages instead of a `400` status.
- Enhances logging verbosity across all error types to improve debugging and operational visibility.
- Adjusts relevant tests (authentication and send_notification) to align with the updated API responses.
- Removes deprecated warnings related to the websockets library.

**Why it is needed:**
On 2025-01-03, the Tibber GraphQL API changed authentication error handling, switching from a `400` HTTP status to a `200` status with detailed error messages (extensions.code: `UNAUTHENTICATED`). Aligning with this new behavior ensures the application correctly interprets authentication errors and remains compliant with the updated API standard.

**How it was implemented:**

- Modified response_handler logic to detect authentication errors based on the `errors` array's `extensions.code` property (specifically, `UNAUTHENTICATED`).
- Updated unit tests to reflect the new error message structures.
- Enhanced logging statements to capture and report error details across different types, facilitating easier troubleshooting.
- Eliminated `DeprecationWarning` related to the `websockets` library to maintain clean test outputs and future compatibility.

**Additional notes:**

- Thoroughly tested with Python versions `3.11`, `3.12`, and especially `3.13`, as `3.13` is now the minimum supported version for Home Assistant.
- All unit tests pass successfully, along with `ruff` and `mypy` static analysis checks.

**References:**

- [API Changelog](https://developer.tibber.com/docs/changelog)
- [Home Assistant Core dependency list](https://github.com/home-assistant/core/blob/892b78a1f9ebe18c3ffc38c4f5b879fe1b1aae33/pyproject.toml#L31)