### PR TITLE
Fix api changes 2025 01 03

### DIFF
--- a/test/test_tibber.py
+++ b/test/test_tibber.py
@@ -82,7 +82,7 @@ async def test_tibber_invalid_token():
             websession=session,
             user_agent="test",
         )
-        with pytest.raises(InvalidLoginError, match="Context creation failed: invalid token"):
+        with pytest.raises(InvalidLoginError, match="No valid access token in request"):
             await tibber_connection.update_info()
         assert not tibber_connection.name
         assert tibber_connection.get_homes() == []

--- a/test/test_tibber.py
+++ b/test/test_tibber.py
@@ -9,7 +9,7 @@ import pytest
 
 import tibber
 from tibber.const import RESOLUTION_DAILY
-from tibber.exceptions import FatalHttpExceptionError, InvalidLoginError
+from tibber.exceptions import FatalHttpExceptionError, InvalidLoginError, NotForDemoUserError
 
 
 @pytest.mark.asyncio
@@ -110,8 +110,8 @@ async def test_tibber_notification():
             websession=session,
             user_agent="test",
         )
-        await tibber_connection.update_info()
-        assert not await tibber_connection.send_notification("Test tittle", "message")
+        with pytest.raises(NotForDemoUserError, match="operation not allowed for demo user"):
+            await tibber_connection.send_notification("Test title", "message")
 
 
 @pytest.mark.asyncio

--- a/tibber/exceptions.py
+++ b/tibber/exceptions.py
@@ -41,3 +41,7 @@ class RetryableHttpExceptionError(HttpExceptionError):
 
 class InvalidLoginError(FatalHttpExceptionError):
     """Invalid login exception."""
+
+
+class NotForDemoUserError(FatalHttpExceptionError):
+    """Exception raised when trying to use a feature not available for demo users"""

--- a/tibber/response_handler.py
+++ b/tibber/response_handler.py
@@ -49,6 +49,10 @@ async def extract_response_data(response: ClientResponse) -> dict[Any, Any]:
 
         error_code, error_message = extract_error_details(errors, str(response.content))
 
+        if error_code == "UNAUTHENTICATED":
+            _LOGGER.error("InvalidLoginError %s %s", error_message, error_code)
+            raise InvalidLoginError(response.status, error_message, error_code)
+
         if (error_code == "INTERNAL_SERVER_ERROR") & ("demo user" in error_message):
             _LOGGER.error("NotForDemoUserError %s %s", error_message, error_code)
             raise NotForDemoUserError(response.status, error_message, error_code)

--- a/tibber/response_handler.py
+++ b/tibber/response_handler.py
@@ -15,6 +15,7 @@ from .const import (
 from .exceptions import (
     FatalHttpExceptionError,
     InvalidLoginError,
+    NotForDemoUserError,
     RetryableHttpExceptionError,
 )
 
@@ -39,11 +40,18 @@ async def extract_response_data(response: ClientResponse) -> dict[Any, Any]:
             API_ERR_CODE_UNKNOWN,
         )
 
-    result = await response.json()
+    result: dict[str, Any] = await response.json()
 
     if response.status == HTTPStatus.OK:
-        return result
+        errors: list[dict[str, Any]] = result.get("errors", [])
+        if not errors:
+            return result
 
+        error_code, error_message = extract_error_details(errors, str(response.content))
+
+        if (error_code == "INTERNAL_SERVER_ERROR") & ("demo user" in error_message):
+            _LOGGER.error("NotForDemoUserError %s %s", error_message, error_code)
+            raise NotForDemoUserError(response.status, error_message, error_code)
     if response.status in HTTP_CODES_RETRIABLE:
         error_code, error_message = extract_error_details(result.get("errors", []), str(response.content))
 

--- a/tibber/response_handler.py
+++ b/tibber/response_handler.py
@@ -50,7 +50,6 @@ async def extract_response_data(response: ClientResponse) -> dict[Any, Any]:
         error_code, error_message = extract_error_details(errors, str(response.content))
 
         if error_code == "UNAUTHENTICATED":
-            _LOGGER.error("InvalidLoginError %s %s", error_message, error_code)
             raise InvalidLoginError(response.status, error_message, error_code)
 
         if (error_code == "INTERNAL_SERVER_ERROR") & ("demo user" in error_message):

--- a/tibber/response_handler.py
+++ b/tibber/response_handler.py
@@ -53,7 +53,6 @@ async def extract_response_data(response: ClientResponse) -> dict[Any, Any]:
             raise InvalidLoginError(response.status, error_message, error_code)
 
         if (error_code == "INTERNAL_SERVER_ERROR") & ("demo user" in error_message):
-            _LOGGER.error("NotForDemoUserError %s %s", error_message, error_code)
             raise NotForDemoUserError(response.status, error_message, error_code)
     if response.status in HTTP_CODES_RETRIABLE:
         error_code, error_message = extract_error_details(result.get("errors", []), str(response.content))


### PR DESCRIPTION
**What this PR does:**
- Updates the response_handler to correctly handle authentication errors according to the recent API changes, which now return a `200` HTTP status with detailed error messages instead of a `400` status.
- Adjusts relevant tests (authentication and send_notification) to align with the updated API responses.


<details><summary><b>Why it is needed:</b></summary>
<p>
On 2025-01-03, the Tibber GraphQL API changed authentication error handling, switching from a `400` HTTP status to a `200` status with detailed error messages (extensions.code: `UNAUTHENTICATED`). Aligning with this new behavior ensures the application correctly interprets authentication errors and remains compliant with the updated API standard.

But also other Errors are packed inside status code 200 responses, therefore "invalid token errors" & "demo token errors" need to be addressed there, too.

</p>
</details> 

**Additional notes:**
- Code Checker workflow completed [successfully](https://github.com/n0l1n/pyTibber/actions/runs/14055442629).

**References:**
- [API Changelog](https://developer.tibber.com/docs/changelog)

**Reviewers to assign:** 
- @Danielhiversen 