### PR TITLE
Revert "Treat `ended` subscription as active when within validity period"

### DIFF
--- a/tibber/home.py
+++ b/tibber/home.py
@@ -308,14 +308,9 @@ class TibberHome:
 
     @property
     def has_active_subscription(self) -> bool:
-        """Return true if the subscription is active."""
+        """Return home id."""
         try:
-            sub = self.info["viewer"]["home"]["currentSubscription"]
-            status = sub["status"]
-            valid_to = sub["validTo"]
-
-            if status == "ended" and valid_to is not None:
-                return dt.datetime.fromisoformat(valid_to) >= dt.datetime.now(self._tibber_control.time_zone)
+            sub = self.info["viewer"]["home"]["currentSubscription"]["status"]
         except (KeyError, TypeError):
             return False
         return sub in [


### PR DESCRIPTION
Reverts Danielhiversen/pyTibber#340

I have to revert this again. It still incorrect return False