### PR TITLE
Fix breaking changes from gql update causing issues in the Home Assistant Tibber integration.

### DIFF
--- a/tibber/realtime.py
+++ b/tibber/realtime.py
@@ -8,7 +8,6 @@ from ssl import SSLContext
 from typing import Any
 
 from gql import Client
-from gql.transport.websockets import log as websockets_logger
 
 from .exceptions import SubscriptionEndpointMissingError
 from .home import TibberHome
@@ -18,6 +17,7 @@ LOCK_CONNECT = asyncio.Lock()
 
 _LOGGER = logging.getLogger(__name__)
 
+websockets_logger = logging.getLogger("gql.transport.websockets")
 websockets_logger.setLevel(logging.WARNING)
 
 


### PR DESCRIPTION
Fixes home-assistant/core#150967

This PR resolves an issue where the Tibber integration in Home Assistant was failing to load existing devices and preventing adding Tibber devices due to changes made in GraphQL client for Python.

Changes made:
- Resolved issue related to the log variable not being exposed by gql causing an import error. 
- Resolved issue due to changes in gql api, the websocket attribute was removed from the WebsocketsTransport class. 
- Updated the websocket transport close method to use the updated gql api method. 
- Modified exception handling in the websocket transport class to also catch the TransportClosed exception.