### PR TITLE
Fix real time subscription + Fix unset has_real_time_consumption

### DIFF
--- a/tibber/home.py
+++ b/tibber/home.py
@@ -218,6 +218,9 @@ class TibberHome:
             _LOGGER.error("Missing 'home' key in viewer for home %s: %s", self._home_id, err)
             self.price_total = {}
             return
+        
+        self._update_has_real_time_consumption()
+
         current_subscription = home.get("currentSubscription")
         if current_subscription is None:
             _LOGGER.debug("No active subscription for home %s", self._home_id)
@@ -237,9 +240,6 @@ class TibberHome:
         except (KeyError, TypeError) as err:
             _LOGGER.error("Malformed price info data for home %s: %s", self._home_id, err)
             self.price_total = {}
-
-        if self.has_active_subscription:
-            self._update_has_real_time_consumption()
 
     def _update_has_real_time_consumption(self) -> None:
         try:

--- a/tibber/home.py
+++ b/tibber/home.py
@@ -208,19 +208,16 @@ class TibberHome:
         # Access currentSubscription, handle missing keys
         try:
             viewer = self.info["viewer"]
-        except KeyError as err:
-            _LOGGER.error("Missing 'viewer' key in info for home %s: %s", self._home_id, err)
-            self.price_total = {}
-            return
-        try:
             home = viewer["home"]
         except KeyError as err:
-            _LOGGER.error("Missing 'home' key in viewer for home %s: %s", self._home_id, err)
+            _LOGGER.error("Missing required key in API response for home %s: %s", self._home_id, err)
             self.price_total = {}
             return
-        
+
+        # Update real-time consumption capability status
         self._update_has_real_time_consumption()
 
+        # Extract price information
         current_subscription = home.get("currentSubscription")
         if current_subscription is None:
             _LOGGER.debug("No active subscription for home %s", self._home_id)

--- a/tibber/websocket_transport.py
+++ b/tibber/websocket_transport.py
@@ -7,7 +7,6 @@ from ssl import SSLContext
 
 from gql.transport.exceptions import TransportClosed
 from gql.transport.websockets import WebsocketsTransport
-from websockets.asyncio.connection import State
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -31,8 +30,6 @@ class TibberWebsocketsTransport(WebsocketsTransport):
     @property
     def running(self) -> bool:
         """Is real time subscription running."""
-        # The parent class WebsocketsTransport uses _connected boolean to track connection state
-        # instead of exposing the raw websocket object
         return getattr(self, "_connected", False)
 
     async def _receive(self) -> str:

--- a/tibber/websocket_transport.py
+++ b/tibber/websocket_transport.py
@@ -31,7 +31,9 @@ class TibberWebsocketsTransport(WebsocketsTransport):
     @property
     def running(self) -> bool:
         """Is real time subscription running."""
-        return hasattr(self, "websocket") and self.websocket is not None and self.websocket.state is State.OPEN
+        # The parent class WebsocketsTransport uses _connected boolean to track connection state
+        # instead of exposing the raw websocket object
+        return getattr(self, "_connected", False)
 
     async def _receive(self) -> str:
         """Wait the next message from the websocket connection."""


### PR DESCRIPTION
With the help of copilot I debugged why the realtime websocket connection never got in the connected state.
It seems with some changes in the underlying "gql" library (v4), the websocket attribute is not anymore populated.
Thus, we are using the `_connected` property to check for the running state.

Next to that, with the change "Handle inactive homes" (https://github.com/Danielhiversen/pyTibber/pull/359) the logic was adjusted, so that the property `has_real_time_consumption` is never set when there is no active subscription (this change was introduced with https://github.com/Danielhiversen/pyTibber/commit/0056df0f1e70664d890ca505bc662f1757c71f43)
[Danielhiversen/pyTibber@master/tibber/home.py#L241](https://github.com/Danielhiversen/pyTibber/blob/master/tibber/home.py?rgh-link-date=2025-10-02T10%3A51%3A48.000Z#L241)

I adjusted it to not check for an active subscription and moved it up so that it is not affected by early returns for price checks.

This is specifically relevant, because in the HomeAssistant integration, the real time coordinator is only started when `has_real_time_consumption` is set to true.
https://github.com/home-assistant/core/blob/master/homeassistant/components/tibber/sensor.py#L296