### PR TITLE
Change handling of "stale" data.

### DIFF
--- a/tibber/home.py
+++ b/tibber/home.py
@@ -493,9 +493,12 @@ class TibberHome:
     @property
     def rt_subscription_running(self) -> bool:
         """Is real time subscription running."""
-        if not self._tibber_control.realtime.subscription_running:
-            return False
-        return not self._last_rt_data_received < dt.datetime.now(tz=dt.UTC) - dt.timedelta(seconds=60)
+        return self._tibber_control.realtime.subscription_running
+
+    @property
+    def rt_data_stale(self) -> bool:
+        """Is real time data stale."""
+        return self._last_rt_data_received < dt.datetime.now(tz=dt.UTC) - dt.timedelta(seconds=60)
 
     async def get_historic_data(
         self,

--- a/tibber/realtime.py
+++ b/tibber/realtime.py
@@ -111,9 +111,7 @@ class TibberRT:
         assert isinstance(self.sub_manager.transport, TibberWebsocketsTransport)
 
         await asyncio.sleep(60)
-
         _retry_count = 0
-        next_test_all_homes_running = dt.datetime.now(tz=dt.UTC)
         while self._watchdog_running:
             await asyncio.sleep(5)
             if (
@@ -122,28 +120,10 @@ class TibberRT:
                 > dt.datetime.now(
                     tz=dt.UTC,
                 )
-                and dt.datetime.now(tz=dt.UTC) > next_test_all_homes_running
             ):
-                is_running = True
-                for home in self._homes:
-                    _LOGGER.debug(
-                        "Watchdog: Checking if home %s is alive, %s, %s",
-                        home.home_id,
-                        home.has_real_time_consumption,
-                        home.rt_subscription_running,
-                    )
-                    if not home.rt_subscription_running:
-                        is_running = False
-                        next_test_all_homes_running = dt.datetime.now(tz=dt.UTC) + dt.timedelta(seconds=60)
-                        break
-                    _LOGGER.debug(
-                        "Watchdog: Home %s is alive",
-                        home.home_id,
-                    )
-                if is_running:
-                    _retry_count = 0
-                    _LOGGER.debug("Watchdog: Connection is alive")
-                    continue
+                _retry_count = 0
+                _LOGGER.debug("Watchdog: Connection is alive")
+                continue
 
             self.sub_manager.transport.reconnect_at = dt.datetime.now(tz=dt.UTC) + dt.timedelta(seconds=self._timeout)
             _LOGGER.error(


### PR DESCRIPTION
### Summary of Changes

The `rt_data_stale` property was added to separate **data monitoring** from **connection management**:

- **Decoupled Health Check:** The watchdog no longer uses data arrival to decide if it should reconnect. It now relies only on transport-level signals (WebSocket pings/timeouts).
- **New `rt_data_stale` Property:** Provides a boolean flag indicating if real-time data is older than 60 seconds, allowing users to monitor data flow independently.
- **Modified `rt_subscription_running`:** Now strictly reports if the WebSocket connection is active, preventing unnecessary reconnect cycles when data is simply delayed.
- **Improved Stability:** Reduces API load and prevents "reconnect storms" during periods of low data frequency or API instability.