### PR TITLE
Fix merging of consumption data if changed retroactively from tibber

### DIFF
--- a/test/test_tibber.py
+++ b/test/test_tibber.py
@@ -272,9 +272,10 @@ async def test_fetch_consumption_data_merges_using_two_predefined_payloads(
 
     async def mock_get_historic_data(
         _n_hours: int,
-        _resolution: str = RESOLUTION_HOURLY,
-        _production: bool = False,
+        resolution: str = RESOLUTION_HOURLY,
+        production: bool = False,
     ) -> list[dict]:
+        _ = (resolution, production)
         return next(payloads)
 
     async with aiohttp.ClientSession() as session:
@@ -312,9 +313,10 @@ async def test_fetch_consumption_data_does_not_duplicate_overlapping_timestamp(
 
     async def mock_get_historic_data(
         _n_hours: int,
-        _resolution: str = RESOLUTION_HOURLY,
-        _production: bool = False,
+        resolution: str = RESOLUTION_HOURLY,
+        production: bool = False,
     ) -> list[dict]:
+        _ = (resolution, production)
         return next(payloads)
 
     async with aiohttp.ClientSession() as session:

--- a/test/test_tibber.py
+++ b/test/test_tibber.py
@@ -3,6 +3,7 @@
 import asyncio
 import datetime as dt
 import logging
+from typing import Self
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import aiohttp
@@ -103,10 +104,18 @@ class FixedDateTime(dt.datetime):
     current = dt.datetime(2026, 5, 6, 2, 30, 0, tzinfo=dt.UTC)
 
     @classmethod
-    def now(cls, tz: dt.tzinfo | None = None) -> dt.datetime:
+    def now(cls, tz: dt.tzinfo | None = None) -> Self:
         if tz is None:
-            return cls.current.replace(tzinfo=None)
-        return cls.current.astimezone(tz)
+            return cls(
+                cls.current.year,
+                cls.current.month,
+                cls.current.day,
+                cls.current.hour,
+                cls.current.minute,
+                cls.current.second,
+                cls.current.microsecond,
+            )
+        return cls.fromtimestamp(cls.current.timestamp(), tz=tz)
 
 
 @pytest.mark.asyncio

--- a/test/test_tibber.py
+++ b/test/test_tibber.py
@@ -3,16 +3,110 @@
 import asyncio
 import datetime as dt
 import logging
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import aiohttp
 import pytest
 
 import tibber
 import tibber.realtime as tibber_realtime
-from tibber.const import RESOLUTION_DAILY
+from tibber.const import RESOLUTION_DAILY, RESOLUTION_HOURLY
 from tibber.exceptions import FatalHttpExceptionError, InvalidLoginError, NotForDemoUserError
 from tibber.websocket_transport import TibberWebsocketsTransport
+
+
+@pytest.fixture
+def initial_hourly_data() -> list[dict]:
+    """Initial dataset stored after first fetch."""
+    base_time = dt.datetime(2026, 5, 6, 0, 0, 0, tzinfo=dt.UTC)
+    return [
+        {
+            "from": (base_time - dt.timedelta(hours=5)).isoformat(),
+            "to": (base_time - dt.timedelta(hours=4)).isoformat(),
+            "consumption": 0.9,
+            "cost": 0.45,
+        },
+        {
+            "from": (base_time - dt.timedelta(hours=4)).isoformat(),
+            "to": (base_time - dt.timedelta(hours=3)).isoformat(),
+            "consumption": 1.1,
+            "cost": 0.55,
+        },
+        {
+            "from": (base_time - dt.timedelta(hours=3)).isoformat(),
+            "to": (base_time - dt.timedelta(hours=2)).isoformat(),
+            "consumption": 1.3,
+            "cost": 0.65,
+        },
+        {
+            "from": (base_time - dt.timedelta(hours=2)).isoformat(),
+            "to": (base_time - dt.timedelta(hours=1)).isoformat(),
+            "consumption": 1.0,
+            "cost": 0.5,
+        },
+        {
+            "from": (base_time - dt.timedelta(hours=1)).isoformat(),
+            "to": base_time.isoformat(),
+            "consumption": 1.5,
+            "cost": 0.75,
+        },
+    ]
+
+
+@pytest.fixture
+def updated_hourly_data() -> list[dict]:
+    """Second dataset with unchanged, corrected and new timestamps."""
+    base_time = dt.datetime(2026, 5, 6, 0, 0, 0, tzinfo=dt.UTC)
+    return [
+        {
+            "from": (base_time - dt.timedelta(hours=4)).isoformat(),
+            "to": (base_time - dt.timedelta(hours=3)).isoformat(),
+            "consumption": 1.1,
+            "cost": 0.55,
+        },
+        {
+            "from": (base_time - dt.timedelta(hours=3)).isoformat(),
+            "to": (base_time - dt.timedelta(hours=2)).isoformat(),
+            "consumption": 1.7,
+            "cost": 0.85,
+        },
+        {
+            "from": (base_time - dt.timedelta(hours=2)).isoformat(),
+            "to": (base_time - dt.timedelta(hours=1)).isoformat(),
+            "consumption": 1.0,
+            "cost": 0.5,
+        },
+        {
+            "from": (base_time - dt.timedelta(hours=1)).isoformat(),
+            "to": base_time.isoformat(),
+            "consumption": 2.2,
+            "cost": 1.1,
+        },
+        {
+            "from": base_time.isoformat(),
+            "to": (base_time + dt.timedelta(hours=1)).isoformat(),
+            "consumption": 1.2,
+            "cost": 0.6,
+        },
+        {
+            "from": (base_time + dt.timedelta(hours=1)).isoformat(),
+            "to": (base_time + dt.timedelta(hours=2)).isoformat(),
+            "consumption": 1.4,
+            "cost": 0.7,
+        },
+    ]
+
+
+class FixedDateTime(dt.datetime):
+    """Controllable datetime for deterministic fetch intervals."""
+
+    current = dt.datetime(2026, 5, 6, 2, 30, 0, tzinfo=dt.UTC)
+
+    @classmethod
+    def now(cls, tz: dt.tzinfo | None = None) -> dt.datetime:
+        if tz is None:
+            return cls.current.replace(tzinfo=None)
+        return cls.current.astimezone(tz)
 
 
 @pytest.mark.asyncio
@@ -155,6 +249,83 @@ async def test_tibber_get_historic_data():
         assert len(historic_data) == 5
         assert historic_data[0]["from"] == "2024-01-01T00:00:00.000+01:00", "First day must be 2024-01-01"
         assert historic_data[4]["from"] == "2024-01-05T00:00:00.000+01:00", "Last day must be 2024-01-05"
+
+
+@pytest.mark.asyncio
+async def test_fetch_consumption_data_merges_using_two_predefined_payloads(
+    monkeypatch: pytest.MonkeyPatch,
+    initial_hourly_data: list[dict],
+    updated_hourly_data: list[dict],
+) -> None:
+    """Second fetch merges old and new values through public API."""
+    FixedDateTime.current = dt.datetime(2026, 5, 6, 2, 30, 0, tzinfo=dt.UTC)
+    payloads = iter([initial_hourly_data, updated_hourly_data])
+
+    async def mock_get_historic_data(
+        _n_hours: int,
+        _resolution: str = RESOLUTION_HOURLY,
+        _production: bool = False,
+    ) -> list[dict]:
+        return next(payloads)
+
+    async with aiohttp.ClientSession() as session:
+        tibber_connection = tibber.Tibber(websession=session, user_agent="test")
+        await tibber_connection.update_info()
+        home = tibber_connection.get_homes()[0]
+
+        monkeypatch.setattr(home, "get_historic_data", mock_get_historic_data)
+
+        with patch("tibber.home.dt.datetime", FixedDateTime):
+            await home.fetch_consumption_data()
+            FixedDateTime.current = dt.datetime(2026, 5, 6, 4, 30, 0, tzinfo=dt.UTC)
+            await home.fetch_consumption_data()
+
+        assert home.hourly_consumption_data == [
+            initial_hourly_data[0],
+            updated_hourly_data[0],
+            updated_hourly_data[1],
+            updated_hourly_data[2],
+            updated_hourly_data[3],
+            updated_hourly_data[4],
+            updated_hourly_data[5],
+        ]
+
+
+@pytest.mark.asyncio
+async def test_fetch_consumption_data_does_not_duplicate_overlapping_timestamp(
+    monkeypatch: pytest.MonkeyPatch,
+    initial_hourly_data: list[dict],
+    updated_hourly_data: list[dict],
+) -> None:
+    """Overlapping hour should be replaced, not duplicated."""
+    FixedDateTime.current = dt.datetime(2026, 5, 6, 2, 15, 0, tzinfo=dt.UTC)
+    payloads = iter([initial_hourly_data, updated_hourly_data])
+
+    async def mock_get_historic_data(
+        _n_hours: int,
+        _resolution: str = RESOLUTION_HOURLY,
+        _production: bool = False,
+    ) -> list[dict]:
+        return next(payloads)
+
+    async with aiohttp.ClientSession() as session:
+        tibber_connection = tibber.Tibber(websession=session, user_agent="test")
+        await tibber_connection.update_info()
+        home = tibber_connection.get_homes()[0]
+
+        monkeypatch.setattr(home, "get_historic_data", mock_get_historic_data)
+
+        with patch("tibber.home.dt.datetime", FixedDateTime):
+            await home.fetch_consumption_data()
+            FixedDateTime.current = dt.datetime(2026, 5, 6, 4, 15, 0, tzinfo=dt.UTC)
+            await home.fetch_consumption_data()
+
+        merged_by_timestamp = {entry["from"]: entry for entry in home.hourly_consumption_data}
+
+        assert len(home.hourly_consumption_data) == 7
+        assert len(merged_by_timestamp) == 7
+        assert merged_by_timestamp[updated_hourly_data[0]["from"]] == updated_hourly_data[0]
+        assert merged_by_timestamp[updated_hourly_data[3]["from"]] == updated_hourly_data[3]
 
 
 @pytest.mark.asyncio

--- a/tibber/home.py
+++ b/tibber/home.py
@@ -30,6 +30,7 @@ _LOGGER = logging.getLogger(__name__)
 MIN_IN_HOUR: int = 60
 MIN_IN_QUARTER: int = 15
 
+MIN_REQUESTED_CONSUMPTION_HOURS: int = 3
 
 class HourlyData:
     """Holds hourly data for consumption or production."""
@@ -103,7 +104,7 @@ class TibberHome:
             n_hours = int(seconds_diff / 3600)
             if n_hours < 1:
                 return
-            n_hours = max(2, int(n_hours))
+            n_hours = max(MIN_REQUESTED_CONSUMPTION_HOURS, int(n_hours))
 
         data = await self.get_historic_data(
             n_hours,

--- a/tibber/home.py
+++ b/tibber/home.py
@@ -119,8 +119,18 @@ class TibberHome:
         if not hourly_data.data:
             hourly_data.data = data
         else:
-            hourly_data.data = [entry for entry in hourly_data.data if entry not in data]
-            hourly_data.data.extend(data)
+            merged_by_timestamp: dict[str, dict[Any, Any]] = {}
+
+            for entry in hourly_data.data:
+                if (timestamp := entry.get("from")) and isinstance(timestamp, str):
+                    merged_by_timestamp[timestamp] = entry
+
+            for entry in data:
+                if (timestamp := entry.get("from")) and isinstance(timestamp, str):
+                    # Always prefer the newest payload for an already known hour.
+                    merged_by_timestamp[timestamp] = entry
+
+            hourly_data.data = list(merged_by_timestamp.values())
 
         _month_energy = 0
         _month_money = 0

--- a/tibber/home.py
+++ b/tibber/home.py
@@ -32,6 +32,7 @@ MIN_IN_QUARTER: int = 15
 
 MIN_REQUESTED_CONSUMPTION_HOURS: int = 3
 
+
 class HourlyData:
     """Holds hourly data for consumption or production."""
 

--- a/tibber/home.py
+++ b/tibber/home.py
@@ -86,6 +86,24 @@ class TibberHome:
         self._has_real_time_consumption: None | bool = None
         self._real_time_consumption_suggested_disabled: dt.datetime | None = None
 
+    def _merge_hourly_data(
+        self,
+        existing_data: list[dict[Any, Any]],
+        new_data: list[dict[Any, Any]],
+    ) -> list[dict[Any, Any]]:
+        """Merge hourly payloads by timestamp and prefer the newest entry."""
+        merged_by_timestamp: dict[str, dict[Any, Any]] = {}
+
+        for entry in existing_data:
+            if (timestamp := entry.get("from")) and isinstance(timestamp, str):
+                merged_by_timestamp[timestamp] = entry
+
+        for entry in new_data:
+            if (timestamp := entry.get("from")) and isinstance(timestamp, str):
+                merged_by_timestamp[timestamp] = entry
+
+        return list(merged_by_timestamp.values())
+
     async def _fetch_data(self, hourly_data: HourlyData) -> None:
         """Update hourly consumption or production data asynchronously."""
         now = dt.datetime.now(tz=dt.UTC)
@@ -119,18 +137,7 @@ class TibberHome:
         if not hourly_data.data:
             hourly_data.data = data
         else:
-            merged_by_timestamp: dict[str, dict[Any, Any]] = {}
-
-            for entry in hourly_data.data:
-                if (timestamp := entry.get("from")) and isinstance(timestamp, str):
-                    merged_by_timestamp[timestamp] = entry
-
-            for entry in data:
-                if (timestamp := entry.get("from")) and isinstance(timestamp, str):
-                    # Always prefer the newest payload for an already known hour.
-                    merged_by_timestamp[timestamp] = entry
-
-            hourly_data.data = list(merged_by_timestamp.values())
+            hourly_data.data = self._merge_hourly_data(hourly_data.data, data)
 
         _month_energy = 0
         _month_money = 0


### PR DESCRIPTION
It may occur, that tibber is updating consumtion data of already provided hours retroactively between multiple requests. This usually happens if tibber estimates usage for an hour (which is indicated in the app but does not seem to be in a flag published via the API) on pulse connection error, server hiccups or it does not believe it's readings if hourly consumption is close to zero (which happens for me very often on sunny days because of my small PV - this helps me to debug this issue). This is mostly fixed when the next hour is "billed". (see https://github.com/home-assistant/core/issues/154907)

The library is already requesting at least two hours of data in `_fetch_data()`, but the merging with already cached consumption data is done by comparing the complete dict of every hour which results in duplicate entries in `hourly_data.data` if there is two hours with different consumption data. This may lead to the HA Recorder dropping the updated value instead of the old value that needs to be replaced. (can't confirm this for sure, bad weather in the last days).

This PR changes the merging by comparing the timestamps and overriding already existing ones with new data instead of creating duplicated entries. I've also increased the minimum fetched hours to 3 - just to be sure to not miss retroactive updates on some bad timing or tibber being very slow. If missed the update is gone forever (at least during the lifetime of the object).

Marked this as a draft as I'm still running this to see if it really fixes the HA issue linked. I also want to discuss the increase to 3 hours and to have feedback if I miss something and the merging was intended the way it was.