### PR TITLE
Fix realtime resubscribe using an expired access token + bounded teardown

### DIFF
--- a/test/test_realtime.py
+++ b/test/test_realtime.py
@@ -13,6 +13,7 @@ from gql.transport.common.adapters.websockets import WebSocketsAdapter
 from websockets.asyncio.connection import State
 
 import tibber.realtime as realtime_module
+import tibber.websocket_transport as websocket_transport_module
 from tibber.websocket_transport import TibberWebsocketsTransport
 
 TibberRT = realtime_module.TibberRT
@@ -162,7 +163,7 @@ async def test_set_access_token_resets_connection_while_holding_lock(
 
     async def assert_locked_reset(unsubscribe_homes: bool = False, stop_watchdog: bool = True) -> None:
         assert tibber_rt._access_token == "new_token"  # noqa: SLF001
-        assert realtime_module.LOCK_CONNECT.locked()
+        assert tibber_rt._lock_connect.locked()  # noqa: SLF001
         await reset_connection(unsubscribe_homes=unsubscribe_homes, stop_watchdog=stop_watchdog)
 
     watchdog_runner = asyncio.create_task(asyncio.sleep(60))
@@ -210,12 +211,12 @@ async def test_set_access_token_does_not_reset_queued_connect(
     )
     tibber_rt.sub_endpoint = "wss://test.endpoint"
 
-    await realtime_module.LOCK_CONNECT.acquire()
+    await tibber_rt._lock_connect.acquire()  # noqa: SLF001
     set_token_task = asyncio.create_task(tibber_rt.set_access_token("new_token"))
     await asyncio.sleep(0)
     connect_task = asyncio.create_task(tibber_rt.connect())
     await asyncio.sleep(0)
-    realtime_module.LOCK_CONNECT.release()
+    tibber_rt._lock_connect.release()  # noqa: SLF001
 
     await asyncio.gather(set_token_task, connect_task)
 
@@ -238,7 +239,7 @@ async def test_watchdog_resets_connection_after_releasing_lock(
         return None
 
     async def assert_unlocked_reset(unsubscribe_homes: bool = False, stop_watchdog: bool = True) -> None:
-        assert not realtime_module.LOCK_CONNECT.locked()
+        assert not tibber_rt._lock_connect.locked()  # noqa: SLF001
         await reset_connection(unsubscribe_homes=unsubscribe_homes, stop_watchdog=stop_watchdog)
 
     async def stop_watchdog_reconnect() -> None:
@@ -252,6 +253,82 @@ async def test_watchdog_resets_connection_after_releasing_lock(
     await tibber_rt._watchdog()  # noqa: SLF001
 
     reset_connection.assert_awaited_once_with(unsubscribe_homes=False, stop_watchdog=False)
+
+
+async def test_reconnect_rebuilds_transport_when_token_unchanged(
+    mock_client: MagicMock,
+) -> None:
+    """Rebuild the transport on reconnect even if the refreshed token is unchanged."""
+    tibber_rt = TibberRT(
+        access_token="test_token",
+        timeout=30,
+        user_agent="test_agent",
+        ssl=True,
+        refresh_access_token=AsyncMock(return_value="test_token"),
+    )
+    tibber_rt.sub_endpoint = "wss://test.endpoint"
+
+    await tibber_rt.connect()
+    first_transport = mock_client.transport
+    # Simulate a dead websocket with an expired but unchanged token
+    mock_client.transport.adapter.websocket = MagicMock(state=State.CLOSED)
+
+    await tibber_rt.reconnect()
+
+    mock_client.close_async.assert_awaited_once()
+    assert mock_client.transport is not first_transport
+    assert tibber_rt.subscription_running is True
+
+    await tibber_rt.disconnect()
+
+
+async def test_connect_lock_is_per_instance() -> None:
+    """The connect lock must not be shared between TibberRT instances."""
+    tibber_rt_1 = TibberRT(access_token="token_1", timeout=30, user_agent="test_agent", ssl=True)
+    tibber_rt_2 = TibberRT(access_token="token_2", timeout=30, user_agent="test_agent", ssl=True)
+
+    assert tibber_rt_1._lock_connect is not tibber_rt_2._lock_connect  # noqa: SLF001
+    assert not hasattr(realtime_module, "LOCK_CONNECT")
+
+
+async def test_reset_connection_times_out_on_hanging_close(
+    monkeypatch: pytest.MonkeyPatch,
+    mock_client: MagicMock,
+    tibber_rt: TibberRT,
+) -> None:
+    """A hanging gql close must not deadlock disconnect."""
+    await tibber_rt.connect()
+
+    async def hang() -> None:
+        await asyncio.Event().wait()
+
+    mock_client.close_async = AsyncMock(side_effect=hang)
+    monkeypatch.setattr(realtime_module, "SUB_MANAGER_CLOSE_TIMEOUT", 0.05)
+
+    await asyncio.wait_for(tibber_rt.disconnect(), timeout=1)
+
+    assert tibber_rt.sub_manager is None
+    assert tibber_rt.session is None
+
+
+async def test_transport_close_times_out_on_hanging_wait_closed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A half-dead websocket must not hang transport.close forever."""
+    transport = TibberWebsocketsTransport(
+        url="wss://test.endpoint",
+        access_token="test_token",
+        user_agent="test_agent",
+    )
+
+    async def hang() -> None:
+        await asyncio.Event().wait()
+
+    transport._fail = AsyncMock()  # type: ignore[method-assign]  # noqa: SLF001
+    transport.wait_closed = hang  # type: ignore[method-assign]
+    monkeypatch.setattr(websocket_transport_module, "CLOSE_TIMEOUT", 0.05)
+
+    await asyncio.wait_for(transport.close(), timeout=1)
 
 
 async def test_websocket_transport() -> None:

--- a/test/test_realtime.py
+++ b/test/test_realtime.py
@@ -13,7 +13,6 @@ from gql.transport.common.adapters.websockets import WebSocketsAdapter
 from websockets.asyncio.connection import State
 
 import tibber.realtime as realtime_module
-import tibber.websocket_transport as websocket_transport_module
 from tibber.websocket_transport import TibberWebsocketsTransport
 
 TibberRT = realtime_module.TibberRT
@@ -326,7 +325,7 @@ async def test_transport_close_times_out_on_hanging_wait_closed(
 
     transport._fail = AsyncMock()  # type: ignore[method-assign]  # noqa: SLF001
     transport.wait_closed = hang  # type: ignore[method-assign]
-    monkeypatch.setattr(websocket_transport_module, "CLOSE_TIMEOUT", 0.05)
+    monkeypatch.setattr("tibber.websocket_transport.CLOSE_TIMEOUT", 0.05)
 
     await asyncio.wait_for(transport.close(), timeout=1)
 

--- a/test/test_tibber.py
+++ b/test/test_tibber.py
@@ -10,9 +10,11 @@ import aiohttp
 import pytest
 
 import tibber
+import tibber.home as tibber_home
 import tibber.realtime as tibber_realtime
 from tibber.const import RESOLUTION_DAILY, RESOLUTION_HOURLY
 from tibber.exceptions import FatalHttpExceptionError, InvalidLoginError, NotForDemoUserError
+from tibber.home import TibberHome
 from tibber.websocket_transport import TibberWebsocketsTransport
 
 
@@ -451,3 +453,53 @@ async def test_realtime_set_access_token_reconnects_active_subscription_manager(
     realtime.sub_manager.connect_async.assert_awaited_once_with()
 
     await realtime.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_delayed_resubscribe_uses_reconnect_and_retries(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The delayed resubscribe must use the token-aware reconnect path and retry with backoff."""
+    tibber_control = MagicMock()
+    tibber_control.realtime.subscription_running = False
+    reconnect = AsyncMock(side_effect=[Exception("boom"), Exception("boom"), None])
+    tibber_control.realtime.reconnect = reconnect
+
+    home = TibberHome("home_id", tibber_control)
+    home._rt_callback = lambda _: None  # noqa: SLF001
+    home._rt_stopped = False  # noqa: SLF001
+
+    delays: list[float] = []
+
+    async def fake_sleep(delay: float) -> None:
+        delays.append(delay)
+
+    monkeypatch.setattr(tibber_home.asyncio, "sleep", fake_sleep)
+
+    await home._delayed_resubscribe()  # noqa: SLF001
+
+    assert reconnect.await_count == 3
+    assert delays == [1, 2, 4]
+
+
+@pytest.mark.asyncio
+async def test_delayed_resubscribe_gives_up_after_max_attempts(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The delayed resubscribe must stop retrying after the final attempt."""
+    tibber_control = MagicMock()
+    tibber_control.realtime.subscription_running = False
+    reconnect = AsyncMock(side_effect=Exception("boom"))
+    tibber_control.realtime.reconnect = reconnect
+
+    home = TibberHome("home_id", tibber_control)
+    home._rt_callback = lambda _: None  # noqa: SLF001
+    home._rt_stopped = False  # noqa: SLF001
+
+    delays: list[float] = []
+
+    async def fake_sleep(delay: float) -> None:
+        delays.append(delay)
+
+    monkeypatch.setattr(tibber_home.asyncio, "sleep", fake_sleep)
+
+    await home._delayed_resubscribe()  # noqa: SLF001
+
+    assert reconnect.await_count == 5
+    assert delays == [1, 2, 4, 8, 16]

--- a/test/test_tibber.py
+++ b/test/test_tibber.py
@@ -10,7 +10,6 @@ import aiohttp
 import pytest
 
 import tibber
-import tibber.home as tibber_home
 import tibber.realtime as tibber_realtime
 from tibber.const import RESOLUTION_DAILY, RESOLUTION_HOURLY
 from tibber.exceptions import FatalHttpExceptionError, InvalidLoginError, NotForDemoUserError
@@ -472,7 +471,7 @@ async def test_delayed_resubscribe_uses_reconnect_and_retries(monkeypatch: pytes
     async def fake_sleep(delay: float) -> None:
         delays.append(delay)
 
-    monkeypatch.setattr(tibber_home.asyncio, "sleep", fake_sleep)
+    monkeypatch.setattr("tibber.home.asyncio.sleep", fake_sleep)
 
     await home._delayed_resubscribe()  # noqa: SLF001
 
@@ -497,7 +496,7 @@ async def test_delayed_resubscribe_gives_up_after_max_attempts(monkeypatch: pyte
     async def fake_sleep(delay: float) -> None:
         delays.append(delay)
 
-    monkeypatch.setattr(tibber_home.asyncio, "sleep", fake_sleep)
+    monkeypatch.setattr("tibber.home.asyncio.sleep", fake_sleep)
 
     await home._delayed_resubscribe()  # noqa: SLF001
 

--- a/tibber/home.py
+++ b/tibber/home.py
@@ -32,6 +32,8 @@ MIN_IN_QUARTER: int = 15
 
 MIN_REQUESTED_CONSUMPTION_HOURS: int = 3
 
+RESUBSCRIBE_MAX_ATTEMPTS: int = 5
+
 
 class HourlyData:
     """Holds hourly data for consumption or production."""
@@ -508,17 +510,45 @@ class TibberHome:
         self._resubscribe_task = asyncio.create_task(self._delayed_resubscribe())
 
     async def _delayed_resubscribe(self) -> None:
-        """Delay before retrying the realtime subscription."""
+        """Retry the realtime subscription with backoff after a failure."""
         task = asyncio.current_task()
         try:
-            await asyncio.sleep(1)
-            if self._rt_stopped or self._rt_callback is None:
-                return
-            await self.rt_resubscribe()
-        except asyncio.CancelledError:
-            raise
-        except Exception:
-            _LOGGER.exception("Error in delayed rt_resubscribe")
+            for attempt in range(1, RESUBSCRIBE_MAX_ATTEMPTS + 1):
+                await asyncio.sleep(2 ** (attempt - 1))
+                if self._rt_stopped or self._rt_callback is None:
+                    return
+                if (
+                    self._tibber_control.realtime.subscription_running
+                    and self._rt_listener is not None
+                    and not self._rt_listener.done()
+                ):
+                    _LOGGER.debug("Subscription already restored for %s", self.home_id)
+                    return
+                if self._resubscribe_task is task:
+                    # reconnect() resubscribes all homes, including this one.
+                    # Detach first so rt_unsubscribe does not cancel this task mid-flight.
+                    self._resubscribe_task = None
+                try:
+                    # Use the realtime reconnect, which refreshes the access token before
+                    # rebuilding the websocket transport. Calling rt_resubscribe() directly
+                    # would reuse the cached, possibly expired, token.
+                    await self._tibber_control.realtime.reconnect()
+                except asyncio.CancelledError:
+                    raise
+                except Exception:
+                    if attempt >= RESUBSCRIBE_MAX_ATTEMPTS:
+                        _LOGGER.exception(
+                            "Error in delayed rt_resubscribe, giving up after %s attempts",
+                            attempt,
+                        )
+                    else:
+                        _LOGGER.exception(
+                            "Error in delayed rt_resubscribe (attempt %s of %s)",
+                            attempt,
+                            RESUBSCRIBE_MAX_ATTEMPTS,
+                        )
+                else:
+                    return
         finally:
             if self._resubscribe_task is task:
                 self._resubscribe_task = None

--- a/tibber/realtime.py
+++ b/tibber/realtime.py
@@ -14,7 +14,7 @@ from .exceptions import SubscriptionEndpointMissingError
 from .home import TibberHome
 from .websocket_transport import TibberWebsocketsTransport
 
-LOCK_CONNECT = asyncio.Lock()
+SUB_MANAGER_CLOSE_TIMEOUT = 15
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -43,6 +43,7 @@ class TibberRT:
         self._ssl_context = ssl
         self._refresh_access_token = refresh_access_token
         self._reconnect_lock = asyncio.Lock()
+        self._lock_connect = asyncio.Lock()
 
         self._sub_endpoint: str | None = None
         self._homes: list[TibberHome] = []
@@ -61,14 +62,14 @@ class TibberRT:
 
     async def _reset_connection(self, unsubscribe_homes: bool = False, stop_watchdog: bool = True) -> None:
         """Reset websocket connection state."""
-        async with LOCK_CONNECT:
+        async with self._lock_connect:
             await self._reset_connection_locked(
                 unsubscribe_homes=unsubscribe_homes,
                 stop_watchdog=stop_watchdog,
             )
 
     async def _reset_connection_locked(self, unsubscribe_homes: bool = False, stop_watchdog: bool = True) -> None:
-        """Reset websocket connection state while LOCK_CONNECT is held."""
+        """Reset websocket connection state while the connect lock is held."""
         if stop_watchdog and self._watchdog_runner is not None:
             _LOGGER.debug("Stopping watchdog")
             self._watchdog_running = False
@@ -87,18 +88,24 @@ class TibberRT:
                 )
                 return
 
-            await self.sub_manager.close_async()
+            try:
+                await asyncio.wait_for(self.sub_manager.close_async(), timeout=SUB_MANAGER_CLOSE_TIMEOUT)
+            except TimeoutError:
+                _LOGGER.error(
+                    "Timed out after %s seconds closing the subscription manager, discarding it",
+                    SUB_MANAGER_CLOSE_TIMEOUT,
+                )
         finally:
             self.session = None
             self.sub_manager = None
 
     async def connect(self) -> None:
         """Start subscription manager."""
-        async with LOCK_CONNECT:
+        async with self._lock_connect:
             await self._connect_locked()
 
     async def _connect_locked(self) -> None:
-        """Start subscription manager while LOCK_CONNECT is held."""
+        """Start subscription manager while the connect lock is held."""
         if self.subscription_running:
             return
 
@@ -115,20 +122,22 @@ class TibberRT:
         """Reconnect and resubscribe all homes."""
         async with self._reconnect_lock:
             access_token = await self._refresh_access_token() if self._refresh_access_token is not None else None
-            if access_token is not None:
-                async with LOCK_CONNECT:
-                    if access_token != self._access_token:
-                        self._access_token = access_token
-                        await self._reset_connection_locked(
-                            unsubscribe_homes=self.subscription_running,
-                            stop_watchdog=False,
-                        )
+            async with self._lock_connect:
+                if access_token is not None:
+                    self._access_token = access_token
+                # Always rebuild the transport: the access token is baked into the
+                # transport init_payload at build time, so a refreshed but unchanged
+                # token (or a dead websocket) would otherwise be silently reused.
+                await self._reset_connection_locked(
+                    unsubscribe_homes=self.subscription_running,
+                    stop_watchdog=False,
+                )
             await self.connect()
             await self._resubscribe_homes()
 
     async def set_access_token(self, access_token: str) -> None:
         """Set access token and reconnect active realtime subscriptions."""
-        async with LOCK_CONNECT:
+        async with self._lock_connect:
             restore_connection = self.should_restore_connection
             self._access_token = access_token
             await self._reset_connection_locked(

--- a/tibber/websocket_transport.py
+++ b/tibber/websocket_transport.py
@@ -11,6 +11,8 @@ from websockets.asyncio.connection import State
 
 _LOGGER = logging.getLogger(__name__)
 
+CLOSE_TIMEOUT = 10
+
 
 class TibberWebsocketsTransport(WebsocketsTransport):
     """Tibber websockets transport."""
@@ -56,4 +58,10 @@ class TibberWebsocketsTransport(WebsocketsTransport):
     async def close(self) -> None:
         """Close the websocket connection."""
         await self._fail(TransportClosed(f"Tibber websocket closed by {self._user_agent}"))
-        await self.wait_closed()
+        try:
+            await asyncio.wait_for(self.wait_closed(), timeout=CLOSE_TIMEOUT)
+        except TimeoutError:
+            _LOGGER.error(
+                "Timed out after %s seconds waiting for the Tibber websocket to close",
+                CLOSE_TIMEOUT,
+            )


### PR DESCRIPTION
## Summary

Fixes two related realtime bugs reported against Home Assistant (home-assistant/core#176268, home-assistant/core#168480), plus teardown hangs that wedge HA config-entry unloads into `FAILED_UNLOAD`.

### Bug 1: delayed resubscribe uses the cached (expired) token
After a `TransportError`, `TibberHome._delayed_resubscribe` called `rt_resubscribe()`, which re-authenticates with the **cached** access token. HA's OAuth tokens live ~1 hour and usually expire while the websocket is up, so the resubscribe failed with `InvalidLoginError: "exp" claim timestamp check failed` — and was logged once and **abandoned** (no retry, and `rt_unsubscribe()` had already torn the listener down). This is the endless `Watchdog: Connection is down` loop in core#176268.

**Fix:** `_delayed_resubscribe` now goes through `TibberRT.reconnect()` — the only token-refreshing path — with bounded retries (5 attempts, exponential backoff). It detaches itself before reconnecting so the connection-wide resubscribe can't cancel its own task mid-flight, and early-returns if another path already restored the subscription.

### Bug 2: reconnect() silently reuses an expired token
`reconnect()` only rebuilt the sub_manager when the refreshed token **string** differed from the cached one — but the token is baked into the transport's `init_payload` at construction, so an expired-but-identical token was reused forever. The rebuild now runs unconditionally after a refresh.

### Teardown hardening
- `TibberWebsocketsTransport.close()`: `wait_closed()` bounded to 10 s (a half-dead socket previously blocked forever — this is what deadlocks HA's config-entry unload into `FAILED_UNLOAD`).
- `sub_manager.close_async()` bounded to 15 s in `_reset_connection_locked`.
- The connect lock is now per-instance instead of module-global, so one wedged connection can't block another instance's disconnect.

## Testing
- 6 new unit tests (written to fail against the unpatched code): reconnect-rebuilds-transport-on-unchanged-token, per-instance lock, both close timeouts, and the retry/backoff behaviour of the delayed resubscribe (asserts attempt counts and delays).
- Full suite passes (32 passed), `ruff check`/`ruff format` clean, `mypy` clean.
- **Production testing:** running on a Home Assistant OS instance for 48+ hours, through ~48 hourly OAuth token-rotation reconnect cycles and forced TCP socket kills, with zero stuck connections (previously wedged within a day).
