### PR TITLE
Add token manager

### DIFF
--- a/test/test_data_api.py
+++ b/test/test_data_api.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from tibber.data_api import TibberDataAPI, TibberDevice
+from tibber.token_manager import TokenManager
 
 
 @pytest.fixture
@@ -13,7 +14,7 @@ def data_api() -> TibberDataAPI:
     """Provide a TibberDataAPI instance with a mocked websession."""
     websession = MagicMock()
     return TibberDataAPI(
-        access_token="test-token",
+        token_manager=TokenManager("test-token"),
         timeout=10,
         websession=websession,
         user_agent="test-agent",

--- a/test/test_realtime.py
+++ b/test/test_realtime.py
@@ -17,6 +17,7 @@ from websockets.asyncio.connection import State
 
 from tibber.exceptions import SubscriptionEndpointMissingError, WebsocketReconnectedError, WebsocketTransportError
 from tibber.realtime import TibberRT, TibberWebsocketsTransport
+from tibber.token_manager import TokenManager
 
 if TYPE_CHECKING:
     from collections.abc import Generator
@@ -31,7 +32,7 @@ def timeout() -> int:
 async def tibber_rt_fixture(mock_client: MagicMock, timeout: int) -> TibberRT:  # noqa: ARG001, ASYNC109
     """Create a TibberRT instance for testing."""
     tibber_rt = TibberRT(
-        access_token="test_token",
+        token_manager=TokenManager("test_token"),
         timeout=timeout,
         user_agent="test_agent",
         ssl=True,
@@ -115,7 +116,7 @@ async def test_subscription_running(
 async def test_update_endpoint(mock_client: MagicMock) -> None:
     """Test update subscription endpoint."""
     tibber_rt = TibberRT(
-        access_token="test_token",
+        token_manager=TokenManager("test_token"),
         timeout=30,
         user_agent="test_agent",
         ssl=True,
@@ -178,22 +179,21 @@ async def test_update_endpoint(mock_client: MagicMock) -> None:
     assert mock_client.connect_async.call_count == 2
 
 
-async def test_reconnect_rebuilds_transport_when_token_unchanged(
+async def test_reconnect_always_rebuilds_transport(
     mock_client: MagicMock,
 ) -> None:
-    """Rebuild the transport on reconnect even if the refreshed token is unchanged."""
+    """reconnect() must always tear down and rebuild the transport."""
     tibber_rt = TibberRT(
-        access_token="test_token",
+        token_manager=TokenManager("test_token"),
         timeout=30,
         user_agent="test_agent",
         ssl=True,
-        refresh_access_token=AsyncMock(return_value="test_token"),
     )
     await tibber_rt.set_subscription_endpoint("wss://test.endpoint")
 
     await tibber_rt.connect()
     first_transport = mock_client.transport
-    # Simulate a dead websocket with an expired but unchanged token
+    # Simulate a dead websocket
     mock_client.transport.adapter.websocket = MagicMock(state=State.CLOSED)
 
     await tibber_rt.reconnect()
@@ -211,7 +211,7 @@ async def test_transport_close_times_out_on_hanging_wait_closed(
     """A half-dead websocket must not hang transport.close forever."""
     transport = TibberWebsocketsTransport(
         url="wss://test.endpoint",
-        access_token="test_token",
+        token_manager=TokenManager("test_token"),
         user_agent="test_agent",
         tibber_connected=asyncio.Event(),
     )
@@ -231,7 +231,7 @@ async def test_websocket_transport() -> None:
     tibber_connected = asyncio.Event()
     transport = TibberWebsocketsTransport(
         url="wss://test.endpoint",
-        access_token="test_token",
+        token_manager=TokenManager("test_token"),
         user_agent="test_agent",
         tibber_connected=tibber_connected,
     )
@@ -270,6 +270,64 @@ async def test_websocket_transport() -> None:
     mock_adapter.receive.assert_awaited()
     assert mock_adapter.close.await_count == 1
     assert not tibber_connected.is_set()
+
+
+async def test_initialize_fetches_fresh_token_from_manager() -> None:
+    """_initialize must pull a fresh token from the manager into init_payload before handshake.
+
+    This test guards the gql coupling: if a future gql upgrade renames or removes
+    ``_initialize`` the test will fail loudly, prompting a review of the refresh mechanism.
+    """
+    refresh_callback = AsyncMock(return_value="refreshed_token")
+    token_manager = TokenManager("initial_token", refresh_access_token=refresh_callback)
+    transport = TibberWebsocketsTransport(
+        url="wss://test.endpoint",
+        token_manager=token_manager,
+        user_agent="test_agent",
+        tibber_connected=asyncio.Event(),
+    )
+
+    # Seed a different initial value to verify _initialize overwrites it.
+    assert transport.init_payload["token"] == "initial_token"
+
+    # Stub super()._initialize so we don't need a live websocket.
+    async def noop_super_initialize() -> None:
+        pass
+
+    with patch.object(
+        TibberWebsocketsTransport.__bases__[0],  # WebsocketsTransport
+        "_initialize",
+        new=AsyncMock(side_effect=noop_super_initialize),
+    ):
+        await transport._initialize()  # noqa: SLF001
+
+    assert transport.init_payload["token"] == "refreshed_token"
+    refresh_callback.assert_awaited_once()
+
+
+async def test_initialize_calls_super_after_setting_payload() -> None:
+    """_initialize must call super()._initialize() so the handshake actually runs."""
+    token_manager = TokenManager("test_token")
+    transport = TibberWebsocketsTransport(
+        url="wss://test.endpoint",
+        token_manager=token_manager,
+        user_agent="test_agent",
+        tibber_connected=asyncio.Event(),
+    )
+
+    super_calls: list[str] = []
+
+    async def record_super() -> None:
+        super_calls.append("called")
+
+    with patch.object(
+        TibberWebsocketsTransport.__bases__[0],
+        "_initialize",
+        new=AsyncMock(side_effect=record_super),
+    ):
+        await transport._initialize()  # noqa: SLF001
+
+    assert super_calls == ["called"]
 
 
 async def test_subscribe_raises_when_not_connected(tibber_rt: TibberRT) -> None:
@@ -354,20 +412,37 @@ async def test_reconnect_noop_when_not_connected(
     mock_client.close_async.assert_not_awaited()
 
 
-async def test_set_access_token_reconnects_with_new_token(
+async def test_reconnect_uses_updated_token(
     mock_client: MagicMock,
-    tibber_rt: TibberRT,
 ) -> None:
-    """set_access_token must update the token and reconnect so the new token is used."""
+    """After updating the token in the manager, reconnect must build a transport using it.
+
+    The token is injected into init_payload by _initialize at connect time.  Since
+    mock_client.connect_async does not run the real gql machinery, we verify the manager
+    holds the new token and that a fresh transport was created (old and new are distinct
+    objects).
+    """
+    token_manager = TokenManager("old_token")
+    tibber_rt = TibberRT(
+        token_manager=token_manager,
+        timeout=30,
+        user_agent="test_agent",
+        ssl=True,
+    )
+    await tibber_rt.set_subscription_endpoint("wss://test.endpoint")
+
     await tibber_rt.connect()
+    first_transport = mock_client.transport
     mock_client.connect_async.reset_mock()
     mock_client.close_async.reset_mock()
 
-    await tibber_rt.set_access_token("new_token")
+    token_manager.set_access_token("new_token")
+    await tibber_rt.reconnect()
 
     mock_client.close_async.assert_awaited_once()
     mock_client.connect_async.assert_awaited_once()
-    assert mock_client.transport.init_payload["token"] == "new_token"
+    assert mock_client.transport is not first_transport
+    assert token_manager.access_token == "new_token"
 
 
 @pytest.mark.parametrize("timeout", [0])

--- a/test/test_tibber.py
+++ b/test/test_tibber.py
@@ -359,63 +359,67 @@ async def test_logging_rt_subscribe(caplog: pytest.LogCaptureFixture) -> None:
 
 
 @pytest.mark.asyncio
-async def test_set_access_token_updates_clients(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_set_access_token_emits_deprecation_warning(monkeypatch: pytest.MonkeyPatch) -> None:
+    """set_access_token must emit a DeprecationWarning."""
     tibber_connection = tibber.Tibber(
+        access_token="existing-token",
         websession=MagicMock(),
         user_agent="test",
     )
-    rt_set_access_token = AsyncMock()
-    data_api_set_access_token = MagicMock()
+    monkeypatch.setattr(tibber_connection.realtime, "reconnect", AsyncMock())
 
-    monkeypatch.setattr(tibber_connection.realtime, "set_access_token", rt_set_access_token)
-    monkeypatch.setattr(tibber_connection.data_api, "set_access_token", data_api_set_access_token)
+    with pytest.warns(DeprecationWarning, match="refresh_access_token"):
+        await tibber_connection.set_access_token("new-token")
 
-    await tibber_connection.set_access_token("new-token")
 
-    rt_set_access_token.assert_awaited_once_with("new-token")
-    data_api_set_access_token.assert_called_once_with("new-token")
+@pytest.mark.asyncio
+async def test_set_access_token_updates_shared_token_manager(monkeypatch: pytest.MonkeyPatch) -> None:
+    """set_access_token must update the shared TokenManager that all clients read from."""
+    tibber_connection = tibber.Tibber(
+        access_token="existing-token",
+        websession=MagicMock(),
+        user_agent="test",
+    )
+    monkeypatch.setattr(tibber_connection.realtime, "reconnect", AsyncMock())
+
+    with pytest.warns(DeprecationWarning):
+        await tibber_connection.set_access_token("new-token")
+
+    assert tibber_connection._token_manager.access_token == "new-token"  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_set_access_token_triggers_reconnect(monkeypatch: pytest.MonkeyPatch) -> None:
+    """set_access_token must call reconnect() so an active RT session picks up the new token."""
+    tibber_connection = tibber.Tibber(
+        access_token="existing-token",
+        websession=MagicMock(),
+        user_agent="test",
+    )
+    mock_reconnect = AsyncMock()
+    monkeypatch.setattr(tibber_connection.realtime, "reconnect", mock_reconnect)
+
+    with pytest.warns(DeprecationWarning):
+        await tibber_connection.set_access_token("new-token")
+
+    mock_reconnect.assert_awaited_once()
 
 
 @pytest.mark.asyncio
 async def test_set_access_token_noop_when_token_unchanged(monkeypatch: pytest.MonkeyPatch) -> None:
+    """set_access_token must be a no-op (no reconnect) when the token has not changed."""
     tibber_connection = tibber.Tibber(
         access_token="existing-token",
         websession=MagicMock(),
         user_agent="test",
     )
-    rt_set_access_token = AsyncMock()
-    data_api_set_access_token = MagicMock()
+    mock_reconnect = AsyncMock()
+    monkeypatch.setattr(tibber_connection.realtime, "reconnect", mock_reconnect)
 
-    monkeypatch.setattr(tibber_connection.realtime, "set_access_token", rt_set_access_token)
-    monkeypatch.setattr(tibber_connection.data_api, "set_access_token", data_api_set_access_token)
+    with pytest.warns(DeprecationWarning):
+        await tibber_connection.set_access_token("existing-token")
 
-    await tibber_connection.set_access_token("existing-token")
-
-    rt_set_access_token.assert_not_awaited()
-    data_api_set_access_token.assert_not_called()
-
-
-@pytest.mark.asyncio
-async def test_set_access_token_updates_data_api_before_realtime(monkeypatch: pytest.MonkeyPatch) -> None:
-    """data_api must be reauthorized before realtime, which reuses the refreshed token on reconnect."""
-    tibber_connection = tibber.Tibber(
-        access_token="existing-token",
-        websession=MagicMock(),
-        user_agent="test",
-    )
-    manager = MagicMock()
-    manager.data_api = MagicMock()
-    manager.realtime = AsyncMock()
-
-    monkeypatch.setattr(tibber_connection.realtime, "set_access_token", manager.realtime)
-    monkeypatch.setattr(tibber_connection.data_api, "set_access_token", manager.data_api)
-
-    await tibber_connection.set_access_token("new-token")
-
-    assert manager.mock_calls == [
-        call.data_api("new-token"),
-        call.realtime("new-token"),
-    ]
+    mock_reconnect.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/test/test_token_manager.py
+++ b/test/test_token_manager.py
@@ -1,0 +1,118 @@
+"""Tests for TokenManager."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock
+
+import pytest
+
+from tibber.token_manager import TokenManager
+
+
+async def test_access_token_property_returns_stored_token() -> None:
+    """access_token must return the token set at construction."""
+    manager = TokenManager("initial_token")
+    assert manager.access_token == "initial_token"
+
+
+async def test_set_access_token_updates_stored_token() -> None:
+    """set_access_token must synchronously update the stored token."""
+    manager = TokenManager("old")
+    manager.set_access_token("new")
+    assert manager.access_token == "new"
+
+
+async def test_async_get_access_token_without_callback_returns_stored_token() -> None:
+    """Without a refresh callback, async_get_access_token returns the stored token immediately."""
+    manager = TokenManager("static_token")
+    token = await manager.async_get_access_token()
+    assert token == "static_token"
+
+
+async def test_async_get_access_token_invokes_callback_and_stores_result() -> None:
+    """When a callback is provided, the result is stored and returned."""
+    callback = AsyncMock(return_value="fresh_token")
+    manager = TokenManager("old_token", refresh_access_token=callback)
+
+    token = await manager.async_get_access_token()
+
+    assert token == "fresh_token"
+    assert manager.access_token == "fresh_token"
+    callback.assert_awaited_once()
+
+
+async def test_async_get_access_token_callback_returning_none_keeps_old_token() -> None:
+    """A callback that returns None must leave the stored token unchanged."""
+    callback = AsyncMock(return_value=None)
+    manager = TokenManager("old_token", refresh_access_token=callback)
+
+    token = await manager.async_get_access_token()
+
+    assert token == "old_token"
+    assert manager.access_token == "old_token"
+
+
+async def test_concurrent_calls_coalesce_into_single_callback_invocation() -> None:
+    """Concurrent async_get_access_token() calls must invoke the callback at most once."""
+    call_count = 0
+    release = asyncio.Event()
+
+    async def slow_callback() -> str:
+        nonlocal call_count
+        call_count += 1
+        await release.wait()  # block until all callers have stacked up
+        return "refreshed"
+
+    manager = TokenManager("old", refresh_access_token=slow_callback)
+
+    # Launch several concurrent callers before releasing the callback.
+    tasks = [asyncio.create_task(manager.async_get_access_token()) for _ in range(5)]
+    await asyncio.sleep(0)  # let all tasks reach the shield/await point
+    release.set()
+
+    results = await asyncio.gather(*tasks)
+
+    assert call_count == 1, f"Expected 1 callback invocation, got {call_count}"
+    assert all(r == "refreshed" for r in results)
+
+
+async def test_callback_exception_is_caught_and_last_token_returned() -> None:
+    """An exception raised by the refresh callback must be swallowed and the last token returned.
+
+    The callback is defined outside this library, so we cannot control what it does.
+    Propagating its exceptions into callers would break requests unnecessarily.
+    """
+    callback = AsyncMock(side_effect=RuntimeError("provider unavailable"))
+    manager = TokenManager("last_known", refresh_access_token=callback)
+
+    token = await manager.async_get_access_token()
+
+    assert token == "last_known"
+    assert manager.access_token == "last_known"
+
+
+async def test_cancelled_caller_does_not_cancel_shared_refresh() -> None:
+    """Cancelling one waiter must not abort the in-flight callback for other waiters."""
+    release = asyncio.Event()
+
+    async def slow_callback() -> str:
+        await release.wait()
+        return "done"
+
+    manager = TokenManager("old", refresh_access_token=slow_callback)
+
+    task_a = asyncio.create_task(manager.async_get_access_token())
+    task_b = asyncio.create_task(manager.async_get_access_token())
+
+    await asyncio.sleep(0)  # let both tasks start
+
+    task_a.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task_a
+
+    release.set()
+    result = await task_b
+
+    assert result == "done"
+    assert manager.access_token == "done"

--- a/tibber/__init__.py
+++ b/tibber/__init__.py
@@ -3,6 +3,7 @@
 import asyncio
 import datetime as dt
 import logging
+import warnings
 from collections.abc import Awaitable, Callable
 from ssl import SSLContext
 from typing import Any
@@ -21,6 +22,7 @@ from .gql_queries import INFO, PUSH_NOTIFICATION
 from .home import TibberHome
 from .realtime import TibberRT
 from .response_handler import extract_response_data
+from .token_manager import TokenManager
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -32,6 +34,7 @@ __all__ = [
     "TibberDataAPI",
     "TibberHome",
     "TibberRT",
+    "TokenManager",
 ]
 
 
@@ -56,8 +59,10 @@ class Tibber:
         :param time_zone: The time zone to display times in and to use.
         :param user_agent: User agent identifier for the platform running this. Required if websession is None.
         :param ssl: SSLContext to use.
-        :param refresh_access_token: Async callback that returns a refreshed Tibber API access token before
-            reconnecting.
+        :param refresh_access_token: Async callback that returns a refreshed Tibber API access token.
+            Called before every request; concurrent calls coalesce into a single invocation.
+            This is the recommended mechanism for token refresh — prefer it over
+            :meth:`set_access_token`.
         """
         if websession is None:
             websession = aiohttp.ClientSession(connector=aiohttp.TCPConnector(ssl=ssl))
@@ -68,14 +73,12 @@ class Tibber:
         self._user_agent: str = f"{user_agent} pyTibber/{__version__} "
         self.websession = websession
         self.timeout: int = timeout
-        self._access_token: str = access_token
-        self._refresh_access_token = refresh_access_token
+        self._token_manager = TokenManager(access_token, refresh_access_token=refresh_access_token)
         self.realtime = TibberRT(
-            access_token,
+            self._token_manager,
             timeout,
             self._user_agent,
             ssl=ssl,
-            refresh_access_token=self._refresh_access_token_for_reconnect if refresh_access_token is not None else None,
         )
 
         self.time_zone: dt.tzinfo = time_zone or dt.UTC
@@ -85,23 +88,11 @@ class Tibber:
         self._all_home_ids: list[str] = []
         self._homes: dict[str, TibberHome] = {}
         self.data_api: TibberDataAPI = TibberDataAPI(
-            access_token,
+            self._token_manager,
             timeout=timeout,
             websession=websession,
             user_agent=self._user_agent,
         )
-
-    async def _refresh_access_token_for_reconnect(self) -> str | None:
-        """Refresh access token before reconnecting realtime subscriptions."""
-        if self._refresh_access_token is None:
-            return None
-
-        access_token = await self._refresh_access_token()
-        if access_token is not None and access_token != self._access_token:
-            _LOGGER.debug("Updating access token")
-            self._access_token = access_token
-            self.data_api.set_access_token(access_token)
-        return access_token
 
     async def close_connection(self) -> None:
         """Close the Tibber connection.
@@ -121,7 +112,7 @@ class Tibber:
         :param document: The GraphQL query to request.
         :param variable_values: The GraphQL variables to parse with the request.
         :param timeout: The timeout to use for the request.
-        :param retry: The number of times to retry the request.
+        :param retry: The number of times to retry the request on transport errors.
         """
         timeout = timeout or self.timeout
 
@@ -133,10 +124,11 @@ class Tibber:
             variable_values,
         )
         try:
+            access_token = await self._token_manager.async_get_access_token()
             resp = await self.websession.post(
                 API_ENDPOINT,
                 headers={
-                    "Authorization": "Bearer " + self._access_token,
+                    "Authorization": "Bearer " + access_token,
                     aiohttp.hdrs.USER_AGENT: self._user_agent,
                 },
                 data=payload,
@@ -249,13 +241,26 @@ class Tibber:
         await self.realtime.disconnect()
 
     async def set_access_token(self, access_token: str) -> None:
-        """Set access token and reauthorize clients."""
-        if access_token == self._access_token:
+        """Set access token and reauthorize clients.
+
+        .. deprecated::
+            Prefer providing a ``refresh_access_token`` callback at construction time so all
+            clients share a single token source and the token is refreshed proactively before
+            every request.  This method will be removed in a future release.
+        """
+        warnings.warn(
+            "Tibber.set_access_token is deprecated; provide a refresh_access_token callback "
+            "at construction time instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        if access_token == self._token_manager.access_token:
             return
         _LOGGER.debug("Updating access token")
-        self._access_token = access_token
-        self.data_api.set_access_token(access_token)
-        await self.realtime.set_access_token(access_token)
+        self._token_manager.set_access_token(access_token)
+        # reconnect() is a no-op when not connected; if a live session exists, the new token
+        # is applied immediately so the active subscription does not continue with a stale one.
+        await self.realtime.reconnect()
 
     @property
     def user_id(self) -> str | None:

--- a/tibber/__init__.py
+++ b/tibber/__init__.py
@@ -247,6 +247,10 @@ class Tibber:
             Prefer providing a ``refresh_access_token`` callback at construction time so all
             clients share a single token source and the token is refreshed proactively before
             every request.  This method will be removed in a future release.
+
+            Do not combine this method with a ``refresh_access_token`` callback: when a callback
+            is configured it is the authoritative token source and will overwrite any manually
+            supplied value on the next refresh invocation.
         """
         warnings.warn(
             "Tibber.set_access_token is deprecated; provide a refresh_access_token callback "

--- a/tibber/data_api.py
+++ b/tibber/data_api.py
@@ -7,7 +7,7 @@ import datetime as dt
 import logging
 import random
 from http import HTTPStatus
-from typing import Any, NoReturn, TypeAlias
+from typing import TYPE_CHECKING, Any, NoReturn, TypeAlias
 
 import aiohttp
 
@@ -21,6 +21,9 @@ from .exceptions import (
 )
 from .response_handler import extract_response_data
 
+if TYPE_CHECKING:
+    from .token_manager import TokenManager
+
 _LOGGER = logging.getLogger(__name__)
 
 MAX_RATE_LIMIT_ATTEMPTS = 2
@@ -33,14 +36,15 @@ class TibberDataAPI:
 
     def __init__(
         self,
-        access_token: str,
+        token_manager: TokenManager,
         timeout: int = DEFAULT_TIMEOUT,
         websession: aiohttp.ClientSession | None = None,
         user_agent: str | None = None,
     ) -> None:
         """Initialize the Tibber Data API client.
 
-        :param access_token: The access token to access the Tibber Data API with.
+        :param token_manager: Shared token manager that provides the access token and optional
+            refresh callback.  The token is fetched fresh before every request.
         :param timeout: The timeout in seconds to use when communicating with the API.
         :param websession: The websession to use when communicating with the API.
         :param user_agent: Optional user agent string attached to outgoing requests.
@@ -59,14 +63,18 @@ class TibberDataAPI:
         self.websession = websession
         self._owns_session = owns_session
         self.timeout = timeout
-        self._access_token = access_token
+        self._token_manager = token_manager
         self._user_agent = f"{user_agent} pyTibber/{__version__} "
         self._devices: dict[str, TibberDevice] = {}
         self._rate_limit_attempt = 0
 
     def set_access_token(self, access_token: str) -> None:
-        """Set the access token."""
-        self._access_token = access_token
+        """Set the access token.
+
+        Deprecated: prefer providing a ``refresh_access_token`` callback via
+        ``TokenManager`` so all clients share a single token source.
+        """
+        self._token_manager.set_access_token(access_token)
 
     async def close_connection(self) -> None:
         """Close the Data API connection."""
@@ -88,9 +96,10 @@ class TibberDataAPI:
         :param retry: Number of retries on failure.
         """
         url = f"{DATA_API_ENDPOINT}{endpoint}"
+        access_token = await self._token_manager.async_get_access_token()
 
         headers = {
-            "Authorization": f"Bearer {self._access_token}",
+            "Authorization": f"Bearer {access_token}",
             "Accept": "application/json",
             "Content-Type": "application/json",
         }
@@ -300,8 +309,9 @@ class TibberDataAPI:
 
     async def get_userinfo(self) -> dict[str, Any]:
         """Return OpenID Connect user info for the current access token."""
+        access_token = await self._token_manager.async_get_access_token()
         headers = {
-            "Authorization": f"Bearer {self._access_token}",
+            "Authorization": f"Bearer {access_token}",
             "Accept": "application/json",
         }
 

--- a/tibber/data_api.py
+++ b/tibber/data_api.py
@@ -73,6 +73,10 @@ class TibberDataAPI:
 
         Deprecated: prefer providing a ``refresh_access_token`` callback via
         ``TokenManager`` so all clients share a single token source.
+
+        Do not combine this with a ``refresh_access_token`` callback: when a callback is
+        configured it is the authoritative token source and will overwrite any manually
+        supplied value on the next refresh invocation.
         """
         self._token_manager.set_access_token(access_token)
 

--- a/tibber/realtime.py
+++ b/tibber/realtime.py
@@ -2,7 +2,7 @@
 
 import asyncio
 import logging
-from collections.abc import AsyncGenerator, Awaitable, Callable
+from collections.abc import AsyncGenerator, Callable
 from ssl import SSLContext
 from typing import TYPE_CHECKING, Any, cast
 
@@ -12,6 +12,7 @@ from gql.transport.websockets import WebsocketsTransport
 from tenacity import before_sleep_log, retry, wait_exponential_jitter
 
 from .exceptions import SubscriptionEndpointMissingError, WebsocketReconnectedError, WebsocketTransportError
+from .token_manager import TokenManager
 
 if TYPE_CHECKING:
     from gql.client import AsyncClientSession
@@ -31,27 +32,27 @@ class TibberRT:
 
     def __init__(
         self,
-        access_token: str,
+        token_manager: TokenManager,
         timeout: int,
         user_agent: str,
         ssl: SSLContext | bool,
-        refresh_access_token: Callable[[], Awaitable[str | None]] | None = None,
     ) -> None:
         """Initialize the Tibber connection.
 
-        :param access_token: The access token to access the Tibber API with.
+        :param token_manager: Shared token manager that provides the access token and optional
+            refresh callback.  The token is fetched fresh on every websocket handshake via
+            ``TibberWebsocketsTransport._initialize``.
         :param timeout: The timeout in seconds to use when communicating with the Tibber API.
-        :param user_agent: User agent identifier for the platform running this. Required if websession is None.
-        :param refresh_access_token: Async callback to refresh the access token before reconnecting.
+        :param user_agent: User agent identifier for the platform running this.
+        :param ssl: SSLContext to use.
         """
-        self._access_token: str = access_token
+        self._token_manager = token_manager
         self._timeout: int = timeout
         self._user_agent: str = user_agent
         self._ssl_context = ssl
         self._sub_endpoint: str | None = None
         self._tibber_connected = asyncio.Event()
         self._client: Client | None = None
-        self._refresh_access_token = refresh_access_token
         self._lock_connect = asyncio.Lock()
         self.subscription_running = False
         self._session: AsyncClientSession | None = None
@@ -65,7 +66,7 @@ class TibberRT:
         return Client(
             transport=TibberWebsocketsTransport(
                 self._sub_endpoint,
-                self._access_token,
+                self._token_manager,
                 self._user_agent,
                 connect_timeout=self._timeout,
                 ssl=self._ssl_context,
@@ -100,18 +101,13 @@ class TibberRT:
             return
 
         self._client = self._create_client()
-        # gql's built-in reconnect (reconnecting=True + retry_connect) reuses this transport
-        # instance, so it keeps replaying the access token baked into init_payload at build
-        # time. That means an expired token is not refreshed by gql's internal retry loop.
-        # We deliberately do NOT override gql's connection handshake to refresh mid-retry, as
-        # that reaches into gql internals and collides with the explicit token passed to
-        # set_access_token. Instead, token refresh happens on our own reconnect() path, which
-        # rebuilds the transport with a fresh token. reconnect() is driven by set_access_token,
-        # set_subscription_endpoint, and the per-home subscription timeout watchdog: if an
-        # expired token stalls the stream, the watchdog reconnects within RT_SUBSCRIPTION_TIMEOUT
-        # and refreshes the token. Recovery is therefore a little slower than a dedicated
-        # handshake hook, but avoids coupling to gql internals.
-        # We store a strong reference to the connect task. The task is shielded below so a
+        # Token refresh now happens inside TibberWebsocketsTransport._initialize, which gql
+        # calls on every (re)connect including its internal reconnect loop.  This means gql's
+        # own reconnect self-heals an expired token within one reconnect cycle without any
+        # external intervention. The per-home subscription timeout watchdog remains as a
+        # no-data-received safety net only.
+        #
+        # We store a strong reference to the connect task.  The task is shielded below so a
         # connect timeout does not cancel the ongoing connection attempt, letting it keep
         # retrying in the background. The event loop only keeps weak references to tasks, so
         # without this reference the shielded task could be garbage collected mid-execution.
@@ -146,21 +142,17 @@ class TibberRT:
             self._connect_task = None
 
     async def reconnect(self) -> None:
-        """Reconnect the websocket client."""
+        """Reconnect the websocket client.
+
+        The fresh token is picked up automatically via ``TibberWebsocketsTransport._initialize``
+        on the next gql connect, so no explicit token refresh is performed here.
+        """
         async with self._lock_connect:
             if self._session is None:
                 return
             _LOGGER.debug("Reconnecting websocket client")
-            access_token = await self._refresh_access_token() if self._refresh_access_token is not None else None
-            if access_token is not None:
-                self._access_token = access_token
             await self._disconnect()
             await self._connect()
-
-    async def set_access_token(self, access_token: str) -> None:
-        """Set access token."""
-        self._access_token = access_token
-        await self.reconnect()
 
     async def subscribe(
         self,
@@ -206,7 +198,7 @@ class TibberWebsocketsTransport(WebsocketsTransport):
     def __init__(
         self,
         url: str,
-        access_token: str,
+        token_manager: TokenManager,
         user_agent: str,
         *,
         connect_timeout: float = 10,
@@ -216,7 +208,7 @@ class TibberWebsocketsTransport(WebsocketsTransport):
         """Initialize TibberWebsocketsTransport."""
         super().__init__(
             url=url,
-            init_payload={"token": access_token},
+            init_payload={"token": token_manager.access_token},
             headers={"User-Agent": user_agent},
             ssl=ssl,
             connect_timeout=connect_timeout,
@@ -224,8 +216,24 @@ class TibberWebsocketsTransport(WebsocketsTransport):
             ping_interval=PING_INTERVAL,
             pong_timeout=PONG_TIMEOUT,
         )
+        self._token_manager = token_manager
         self._tibber_connected = tibber_connected
         self._user_agent = user_agent
+
+    async def _initialize(self) -> None:
+        """Fetch a fresh token and send the GraphQL connection_init message.
+
+        gql calls this method on every (re)connect, including its internal reconnect loop, so
+        an expired token is automatically refreshed before each handshake attempt.  This is
+        the mechanism that makes gql's built-in reconnect self-heal expired tokens without
+        requiring an external ``reconnect()`` call.
+
+        Note: this couples us to gql calling ``_initialize`` on each reconnect.  A dedicated
+        unit test in ``test_realtime.py`` guards this assumption so a future gql change that
+        renames or reworks ``_initialize`` fails loudly.
+        """
+        self.init_payload = {"token": await self._token_manager.async_get_access_token()}
+        await super()._initialize()
 
     async def _after_connect(self) -> None:
         """Hook to add custom code for subclasses.

--- a/tibber/realtime.py
+++ b/tibber/realtime.py
@@ -102,12 +102,12 @@ class TibberRT:
 
         self._client = self._create_client()
         # Token refresh now happens inside TibberWebsocketsTransport._initialize, which gql
-        # calls on every (re)connect including its internal reconnect loop.  This means gql's
+        # calls on every (re)connect including its internal reconnect loop. This means gql's
         # own reconnect self-heals an expired token within one reconnect cycle without any
         # external intervention. The per-home subscription timeout watchdog remains as a
         # no-data-received safety net only.
         #
-        # We store a strong reference to the connect task.  The task is shielded below so a
+        # We store a strong reference to the connect task. The task is shielded below so a
         # connect timeout does not cancel the ongoing connection attempt, letting it keep
         # retrying in the background. The event loop only keeps weak references to tasks, so
         # without this reference the shielded task could be garbage collected mid-execution.

--- a/tibber/token_manager.py
+++ b/tibber/token_manager.py
@@ -44,7 +44,12 @@ class TokenManager:
         return self._access_token
 
     def set_access_token(self, access_token: str) -> None:
-        """Update the stored access token synchronously."""
+        """Update the stored access token synchronously.
+
+        Do not combine this with a ``refresh_access_token`` callback.  When a callback is
+        configured it is the single source of truth: the next refresh invocation will overwrite
+        any value written here.  Use one mechanism or the other, not both.
+        """
         self._access_token = access_token
 
     async def async_get_access_token(self) -> str:

--- a/tibber/token_manager.py
+++ b/tibber/token_manager.py
@@ -1,0 +1,83 @@
+"""Token manager for Tibber API clients."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class TokenManager:
+    """Manages the access token and optional refresh callback shared across all Tibber API clients.
+
+    All consumers (``Tibber.execute``, ``TibberDataAPI``, and ``TibberWebsocketsTransport``)
+    share one instance so the token has a single source of truth.  When a refresh callback is
+    provided the token is fetched fresh before every request; concurrent callers coalesce into
+    a single in-flight callback invocation.
+    """
+
+    def __init__(
+        self,
+        access_token: str,
+        *,
+        refresh_access_token: Callable[[], Awaitable[str | None]] | None = None,
+    ) -> None:
+        """Initialize the token manager.
+
+        :param access_token: The initial access token.
+        :param refresh_access_token: Optional async callback that returns a refreshed access
+            token.  Expected to be cheap when the token is still valid (e.g. an OAuth2 session
+            that returns the cached token without a network call).
+        """
+        self._access_token = access_token
+        self._refresh_access_token = refresh_access_token
+        self._refresh_task: asyncio.Task[str] | None = None
+
+    @property
+    def access_token(self) -> str:
+        """Return the last known access token without refreshing (sync, no I/O)."""
+        return self._access_token
+
+    def set_access_token(self, access_token: str) -> None:
+        """Update the stored access token synchronously."""
+        self._access_token = access_token
+
+    async def async_get_access_token(self) -> str:
+        """Return the access token, invoking the refresh callback when configured.
+
+        Concurrent callers coalesce: if a refresh is already in flight, new callers join it
+        rather than starting their own callback invocation.  A cancelled caller does not cancel
+        the shared in-flight refresh (``asyncio.shield``).
+
+        Sequential callers always start a fresh callback invocation — the prior task is
+        ``.done()`` by the time the next awaited call arrives.
+        """
+        if self._refresh_access_token is None:
+            return self._access_token
+        if self._refresh_task is None or self._refresh_task.done():
+            self._refresh_task = asyncio.create_task(self._do_refresh())
+        return await asyncio.shield(self._refresh_task)
+
+    async def _do_refresh(self) -> str:
+        """Invoke the refresh callback and persist the returned token.
+
+        Any exception raised by the callback is caught and logged; the last known token is
+        returned so callers can still attempt a request (which may then fail with a 401 and
+        trigger a retry).
+        """
+        if TYPE_CHECKING:
+            assert self._refresh_access_token is not None
+        try:
+            token = await self._refresh_access_token()
+        except Exception:
+            _LOGGER.exception("Error in refresh_access_token callback, keeping last known token")
+            return self._access_token
+        if token is not None:
+            _LOGGER.debug("Access token refreshed")
+            self._access_token = token
+        return self._access_token


### PR DESCRIPTION
- Consolidate the token reference and refresh into a class.
- The goal is to avoid having multiple token references when using this library in an application. The existing multiple references are allowing the different references to drift apart. Also make the token refresh code simpler, and also the realtime connection less likely to encounter an expired token.


- [x] I need to test the code live for some days, before it could be merged.

closes #448