### PR TITLE
Fix attribute error on network outage

### DIFF
--- a/test/test_realtime.py
+++ b/test/test_realtime.py
@@ -59,6 +59,7 @@ def mock_client_fixture() -> Generator[MagicMock]:
         async def mock_connect_async(**kwargs: Any) -> MagicMock:  # noqa: ANN401, ARG001
             session = mock_client.session = MagicMock(spec=AsyncClientSession)
             mock_client.transport.adapter.websocket = MagicMock(state=State.OPEN)
+            mock_client.transport._tibber_connected.set()  # simulate _after_connect  # noqa: SLF001
             await asyncio.sleep(0)  # Simulate some delay in connecting
             return session
 
@@ -457,3 +458,45 @@ async def test_subscribe_transport_connection_failed_without_on_error_raises_rec
     await unblock_task
 
     assert tibber_rt.subscription_running is True
+
+
+async def test_subscribe_blocks_until_handshake_completes(
+    mock_client: MagicMock,
+    tibber_rt: TibberRT,
+) -> None:
+    """subscribe must wait for _tibber_connected before calling session.subscribe.
+
+    Since the connection may not be finished when connect_async returns,
+    wait for the connected event before subscribing.
+    """
+    await tibber_rt.connect()
+
+    # Simulate the watchdog outage path: reconnect() → _create_client() clears the
+    # event. If the new transport's connect times out, _tibber_connected stays clear.
+    tibber_rt._tibber_connected.clear()  # noqa: SLF001
+
+    subscribe_called = asyncio.Event()
+
+    async def mock_subscribe(*args: Any, **kwargs: Any) -> Any:  # noqa: ANN401, ARG001
+        subscribe_called.set()
+        yield {"key": "value"}
+
+    mock_client.session.subscribe = mock_subscribe
+
+    # subscribe() must block on _tibber_connected.wait() — not call session.subscribe,
+    # which would trigger _send_query on a transport with no subprotocol attribute.
+    results: list[Any] = []
+
+    async def consume() -> None:
+        results.extend([item async for item in tibber_rt.subscribe(MagicMock())])
+
+    task = asyncio.create_task(consume())
+    # Yield once so the task can start and reach _tibber_connected.wait().
+    await asyncio.sleep(0)
+
+    assert not subscribe_called.is_set(), "session.subscribe must not be called before handshake"
+
+    # Simulate the handshake completing (as _after_connect does after reconnect succeeds).
+    tibber_rt._tibber_connected.set()  # noqa: SLF001
+    await task
+    assert results == [{"key": "value"}]

--- a/tibber/realtime.py
+++ b/tibber/realtime.py
@@ -172,6 +172,15 @@ class TibberRT:
         if self._session is None:
             raise RuntimeError("Connect must be called before subscribe")
 
+        # gql's ReconnectingAsyncClientSession exposes the session before the
+        # transport handshake completes, and gql 4.0's _send_query reads
+        # transport.subprotocol, which is only set in _after_connect. Sending a
+        # subscribe query before the handshake therefore raises AttributeError.
+        # Wait for the handshake (which sets subprotocol, then this event) before
+        # subscribing. If it never connects, the per-home watchdog cancels this
+        # task and reconnects.
+        await self._tibber_connected.wait()
+
         try:
             async for result in self._session.subscribe(request):
                 yield result


### PR DESCRIPTION
Since the connection may not be finished when connect_async returns, wait for the connected event before subscribing.

Fixes the following stack trace:
```
Error in subscription
Traceback (most recent call last):
  File "/usr/local/lib/python3.14/site-packages/tibber/home.py", line 456, in _start_listen
    async for _data in self._tibber_control.realtime.subscribe(
    ...<5 lines>...
        self._handle_subscription_data(_data)
  File "/usr/local/lib/python3.14/site-packages/tibber/realtime.py", line 176, in subscribe
    async for result in self._session.subscribe(request):
        yield result
  File "/usr/local/lib/python3.14/site-packages/gql/client.py", line 1426, in subscribe
    async for result in inner_generator:
    ...<13 lines>...
                yield result.data
  File "/usr/local/lib/python3.14/site-packages/gql/client.py", line 2071, in _subscribe
    async for result in inner_generator:
        yield result
  File "/usr/local/lib/python3.14/site-packages/gql/client.py", line 1337, in _subscribe
    async for result in inner_generator:
    ...<11 lines>...
        yield result
  File "/usr/local/lib/python3.14/site-packages/gql/transport/common/base.py", line 281, in subscribe
    query_id: int = await self._send_query(
                    ^^^^^^^^^^^^^^^^^^^^^^^
        request,
        ^^^^^^^^
    )
    ^
  File "/usr/local/lib/python3.14/site-packages/gql/transport/websockets_protocol.py", line 244, in _send_query
    if self.subprotocol == self.GRAPHQLWS_SUBPROTOCOL:
       ^^^^^^^^^^^^^^^^
AttributeError: 'TibberWebsocketsTransport' object has no attribute 'subprotocol'
```