### PR TITLE
Fix realtime consumption disabled grace period

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,50 @@
+"""Shared test fixtures."""
+
+from __future__ import annotations
+
+import datetime as dt
+from typing import ClassVar, Self
+
+import pytest
+
+FROZEN_NOW = dt.datetime(2026, 5, 6, 2, 30, 0, tzinfo=dt.UTC)
+
+
+class FixedDateTime(dt.datetime):
+    """Controllable datetime for deterministic time dependent behaviour."""
+
+    current: ClassVar[dt.datetime] = FROZEN_NOW
+
+    @classmethod
+    def now(cls, tz: dt.tzinfo | None = None) -> Self:
+        if tz is None:
+            return cls(
+                cls.current.year,
+                cls.current.month,
+                cls.current.day,
+                cls.current.hour,
+                cls.current.minute,
+                cls.current.second,
+                cls.current.microsecond,
+            )
+        return cls.fromtimestamp(cls.current.timestamp(), tz=tz)
+
+
+@pytest.fixture
+def frozen_clock() -> type[FixedDateTime]:
+    """Return a controllable datetime subclass, freshly built for each test.
+
+    Install it with `patch("tibber.home.dt.datetime", frozen_clock)` and advance time by assigning
+    `frozen_clock.current`. Building a new subclass per test gives each test its own `current`, so
+    that the class level state cannot leak between tests.
+
+    Use whole second values, so that arithmetic against a timedelta compares exactly. The patch
+    target resolves to the real datetime module, so keep the `with` block as narrow as possible.
+    """
+
+    class FreshClock(FixedDateTime):
+        """A per test clock, so that `current` is not shared with any other test."""
+
+        current: ClassVar[dt.datetime] = FROZEN_NOW
+
+    return FreshClock

--- a/test/test_home.py
+++ b/test/test_home.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import datetime as dt
 import logging
 from typing import TYPE_CHECKING, Any
 from unittest.mock import AsyncMock, MagicMock, call, create_autospec, patch
@@ -13,15 +14,19 @@ import pytest
 import tibber
 from tibber.exceptions import (
     InvalidLoginError,
+    RealTimeConsumptionDisabledError,
     SubscriptionFailedError,
     WebsocketReconnectedError,
     WebsocketTransportError,
 )
 from tibber.gql_queries import INFO, REAL_TIME_CONSUMPTION_ENABLED
+from tibber.home import REAL_TIME_CONSUMPTION_DISABLED_GRACE
 from tibber.realtime import TibberRT
 
 if TYPE_CHECKING:
     from collections.abc import AsyncGenerator
+
+    from .conftest import FixedDateTime
 
 HOME_ID = "test-home-id"
 
@@ -53,10 +58,57 @@ def mock_realtime(tibber_connection: tibber.Tibber) -> MagicMock:
 
 
 @pytest.fixture
-def home(tibber_connection: tibber.Tibber) -> tibber.TibberHome:
+async def home(tibber_connection: tibber.Tibber, mock_websession: MagicMock) -> tibber.TibberHome:
+    """Return a home that already believes real time consumption is enabled.
+
+    The status is seeded through the public API rather than by assigning to the private attribute,
+    so the fixture keeps working across refactors. The post mock is replaced afterwards, so that
+    tests start from a clean call count.
+    """
     home = tibber.TibberHome(HOME_ID, tibber_connection)
-    home._has_real_time_consumption = True  # noqa: SLF001
+    mock_websession.post = _make_status_response(rt_enabled=True)
+    await home.update_real_time_consumption_enabled()
+    mock_websession.post = AsyncMock()
     return home
+
+
+def _status_payload(rt_enabled: bool | None, *, with_features: bool = True) -> dict[str, Any]:
+    """Return a REAL_TIME_CONSUMPTION_ENABLED payload reporting the given status."""
+    home_payload: dict[str, Any] = {"id": HOME_ID}
+    if with_features:
+        home_payload["features"] = {"realTimeConsumptionEnabled": rt_enabled}
+    return {"data": {"viewer": {"home": home_payload}}}
+
+
+def _json_response(payload: dict[str, Any]) -> MagicMock:
+    """Return a mocked 200 JSON response carrying the given payload."""
+    mock_response = MagicMock()
+    mock_response.status = 200
+    mock_response.content_type = "application/json"
+    mock_response.json = AsyncMock(return_value=payload)
+    return mock_response
+
+
+def _make_status_response(rt_enabled: bool) -> AsyncMock:
+    """Return a post mock whose response reports the given real time consumption status."""
+    return AsyncMock(return_value=_json_response(_status_payload(rt_enabled)))
+
+
+def _gql_call(query: str) -> Any:  # noqa: ANN401
+    """Return the expected websession.post call for a GraphQL query."""
+    return call(
+        "https://api.tibber.com/v1-beta/gql",
+        headers={
+            "Authorization": "Bearer test-token",
+            "User-Agent": "test",
+        },
+        data={"query": query, "variables": {}},
+        timeout=aiohttp.ClientTimeout(total=10),
+    )
+
+
+# One resubscribe cycle: refresh the real time consumption status, then refresh info.
+RESUBSCRIBE_HTTP_CALLS = [_gql_call(REAL_TIME_CONSUMPTION_ENABLED % HOME_ID), _gql_call(INFO)]
 
 
 def _make_blocking_subscribe(
@@ -110,29 +162,15 @@ async def test_rt_unsubscribe_noop_when_not_subscribed(home: tibber.TibberHome) 
 @pytest.mark.parametrize("enabled", [True, False])
 async def test_update_real_time_consumption_enabled_without_prior_info(
     mock_websession: MagicMock,
-    home: tibber.TibberHome,
+    tibber_connection: tibber.Tibber,
     enabled: bool,
 ) -> None:
     """Updating the flag must not require info to be populated first."""
-    home._has_real_time_consumption = None  # noqa: SLF001
+    # A freshly constructed home has a never-read status and no info.
+    home = tibber.TibberHome(HOME_ID, tibber_connection)
     assert home.info == {}
 
-    mock_response = MagicMock()
-    mock_response.status = 200
-    mock_response.content_type = "application/json"
-    mock_response.json = AsyncMock(
-        return_value={
-            "data": {
-                "viewer": {
-                    "home": {
-                        "id": HOME_ID,
-                        "features": {"realTimeConsumptionEnabled": enabled},
-                    },
-                },
-            },
-        },
-    )
-    mock_websession.post = AsyncMock(return_value=mock_response)
+    mock_websession.post = _make_status_response(rt_enabled=enabled)
 
     await home.update_real_time_consumption_enabled()
 
@@ -166,88 +204,7 @@ async def test_rt_subscribe_multiple_items_all_delivered(
     home.rt_unsubscribe()
 
 
-@pytest.mark.parametrize(
-    ("real_time_consumption", "http_calls"),
-    [
-        (
-            False,
-            [
-                # Initial subscription (first call returns True)
-                call(
-                    "https://api.tibber.com/v1-beta/gql",
-                    headers={
-                        "Authorization": "Bearer test-token",
-                        "User-Agent": "test",
-                    },
-                    data={"query": REAL_TIME_CONSUMPTION_ENABLED % HOME_ID, "variables": {}},
-                    timeout=aiohttp.ClientTimeout(total=10),
-                ),
-                call(
-                    "https://api.tibber.com/v1-beta/gql",
-                    headers={
-                        "Authorization": "Bearer test-token",
-                        "User-Agent": "test",
-                    },
-                    data={"query": INFO, "variables": {}},
-                    timeout=aiohttp.ClientTimeout(total=10),
-                ),
-                # Resubscription (returns False, so no INFO call)
-                call(
-                    "https://api.tibber.com/v1-beta/gql",
-                    headers={
-                        "Authorization": "Bearer test-token",
-                        "User-Agent": "test",
-                    },
-                    data={"query": REAL_TIME_CONSUMPTION_ENABLED % HOME_ID, "variables": {}},
-                    timeout=aiohttp.ClientTimeout(total=10),
-                ),
-            ],
-        ),
-        (
-            True,
-            [
-                # Initial subscription (first call returns True)
-                call(
-                    "https://api.tibber.com/v1-beta/gql",
-                    headers={
-                        "Authorization": "Bearer test-token",
-                        "User-Agent": "test",
-                    },
-                    data={"query": REAL_TIME_CONSUMPTION_ENABLED % HOME_ID, "variables": {}},
-                    timeout=aiohttp.ClientTimeout(total=10),
-                ),
-                call(
-                    "https://api.tibber.com/v1-beta/gql",
-                    headers={
-                        "Authorization": "Bearer test-token",
-                        "User-Agent": "test",
-                    },
-                    data={"query": INFO, "variables": {}},
-                    timeout=aiohttp.ClientTimeout(total=10),
-                ),
-                # Resubscription (returns True)
-                call(
-                    "https://api.tibber.com/v1-beta/gql",
-                    headers={
-                        "Authorization": "Bearer test-token",
-                        "User-Agent": "test",
-                    },
-                    data={"query": REAL_TIME_CONSUMPTION_ENABLED % HOME_ID, "variables": {}},
-                    timeout=aiohttp.ClientTimeout(total=10),
-                ),
-                call(
-                    "https://api.tibber.com/v1-beta/gql",
-                    headers={
-                        "Authorization": "Bearer test-token",
-                        "User-Agent": "test",
-                    },
-                    data={"query": INFO, "variables": {}},
-                    timeout=aiohttp.ClientTimeout(total=10),
-                ),
-            ],
-        ),
-    ],
-)
+@pytest.mark.parametrize("real_time_consumption", [False, True])
 @pytest.mark.parametrize(
     "error",
     [
@@ -263,7 +220,6 @@ async def test_rt_subscribe_on_error_called_on_exception(
     mock_realtime: MagicMock,
     error: Exception,
     real_time_consumption: bool,
-    http_calls: list,
 ) -> None:
     """on_error must be called when subscribe raises an exception."""
     # Track which call number we're on to return different responses
@@ -324,9 +280,14 @@ async def test_rt_subscribe_on_error_called_on_exception(
     assert caught == [error]
     # resubscription should have been triggered - wait for HTTP calls to complete
     await asyncio.wait_for(resubscribe_called.wait(), timeout=1.0)
-    assert mock_websession.post.call_count == len(http_calls)
-    assert mock_websession.post.call_args_list == http_calls
-    assert home.rt_subscription_running is real_time_consumption
+    # The initial subscribe and the resubscribe after the error each run one full cycle. A single
+    # False reading only arms the grace-period timer, so the home keeps reporting its last known
+    # True and the call sequence is identical whether the resubscribe status query reports True
+    # or False.
+    expected_calls = RESUBSCRIBE_HTTP_CALLS * 2
+    assert mock_websession.post.call_count == len(expected_calls)
+    assert mock_websession.post.call_args_list == expected_calls
+    assert home.rt_subscription_running is True
 
     home.rt_unsubscribe()
 
@@ -709,7 +670,7 @@ async def test_update_real_time_consumption_enabled_handles_malformed_payload(
     mock_websession: MagicMock,
     payload: dict,
 ) -> None:
-    """A malformed payload must resolve the flag to None."""
+    """A malformed payload carries no usable information and must not change the last known status."""
     mock_response = MagicMock()
     mock_response.status = 200
     mock_response.content_type = "application/json"
@@ -718,27 +679,131 @@ async def test_update_real_time_consumption_enabled_handles_malformed_payload(
 
     await home.update_real_time_consumption_enabled()
 
-    assert home.has_real_time_consumption is None
+    # The `home` fixture starts out with a known True status, which a malformed payload
+    # must not overwrite.
+    assert home.has_real_time_consumption is True
 
 
-def _make_enabled_response() -> AsyncMock:
-    """Return a post mock whose response reports real time consumption enabled."""
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"viewer": {"home": {}}},  # missing "features" -> KeyError
+        {"viewer": None},  # not subscriptable -> TypeError
+    ],
+)
+async def test_update_real_time_consumption_enabled_malformed_payload_stays_unknown(
+    tibber_connection: tibber.Tibber,
+    mock_websession: MagicMock,
+    payload: dict,
+) -> None:
+    """A malformed payload must leave a never-read status as unknown (None)."""
+    fresh_home = tibber.TibberHome(HOME_ID, tibber_connection)
+
     mock_response = MagicMock()
     mock_response.status = 200
     mock_response.content_type = "application/json"
-    mock_response.json = AsyncMock(
-        return_value={
-            "data": {
-                "viewer": {
-                    "home": {
-                        "id": HOME_ID,
-                        "features": {"realTimeConsumptionEnabled": True},
-                    },
-                },
-            },
-        },
-    )
-    return AsyncMock(return_value=mock_response)
+    mock_response.json = AsyncMock(return_value={"data": payload})
+    mock_websession.post = AsyncMock(return_value=mock_response)
+
+    await fresh_home.update_real_time_consumption_enabled()
+
+    assert fresh_home.has_real_time_consumption is None
+
+
+async def test_status_false_without_prior_true_sets_false_immediately(
+    tibber_connection: tibber.Tibber,
+    mock_websession: MagicMock,
+) -> None:
+    """A False status with no known True resolves to False directly, with no grace period."""
+    fresh_home = tibber.TibberHome(HOME_ID, tibber_connection)
+    mock_websession.post = _make_status_response(rt_enabled=False)
+
+    await fresh_home.update_real_time_consumption_enabled()
+
+    assert fresh_home.has_real_time_consumption is False
+
+
+async def test_status_single_false_keeps_true_within_grace(
+    home: tibber.TibberHome,
+    mock_websession: MagicMock,
+) -> None:
+    """A single False status following a known True must keep reporting the last known True."""
+    mock_websession.post = _make_status_response(rt_enabled=False)
+
+    await home.update_real_time_consumption_enabled()
+
+    assert home.has_real_time_consumption is True
+
+
+async def test_status_repeated_false_within_grace_stays_true(
+    home: tibber.TibberHome,
+    mock_websession: MagicMock,
+) -> None:
+    """Repeated False statuses inside the grace period must keep reporting the last known True."""
+    mock_websession.post = _make_status_response(rt_enabled=False)
+
+    for _ in range(5):
+        await home.update_real_time_consumption_enabled()
+
+    assert home.has_real_time_consumption is True
+
+
+async def test_status_flips_false_only_strictly_after_grace(
+    home: tibber.TibberHome,
+    mock_websession: MagicMock,
+    frozen_clock: type[FixedDateTime],
+) -> None:
+    """The status must flip to False only once the grace period has been strictly exceeded."""
+    mock_websession.post = _make_status_response(rt_enabled=False)
+    armed = dt.datetime(2026, 5, 6, 0, 0, 0, tzinfo=dt.UTC)
+
+    with patch("tibber.home.dt.datetime", frozen_clock):
+        frozen_clock.current = armed
+        await home.update_real_time_consumption_enabled()
+        assert home.has_real_time_consumption is True
+
+        # Exactly at the boundary the grace period has not been exceeded yet.
+        frozen_clock.current = armed + REAL_TIME_CONSUMPTION_DISABLED_GRACE
+        await home.update_real_time_consumption_enabled()
+        assert home.has_real_time_consumption is True
+
+        frozen_clock.current = armed + REAL_TIME_CONSUMPTION_DISABLED_GRACE + dt.timedelta(seconds=1)
+        await home.update_real_time_consumption_enabled()
+        assert home.has_real_time_consumption is False
+
+
+async def test_status_true_reading_restarts_grace_period(
+    home: tibber.TibberHome,
+    mock_websession: MagicMock,
+    frozen_clock: type[FixedDateTime],
+) -> None:
+    """A True status must clear the grace-period timer so a later, unrelated False starts fresh.
+
+    Regression test: a False -> True -> False sequence must not jump straight to a confirmed
+    disable just because a timer from an earlier, already-recovered-from False was never cleared.
+    """
+    armed = dt.datetime(2026, 5, 6, 0, 0, 0, tzinfo=dt.UTC)
+    past_grace = REAL_TIME_CONSUMPTION_DISABLED_GRACE + dt.timedelta(seconds=1)
+
+    with patch("tibber.home.dt.datetime", frozen_clock):
+        frozen_clock.current = armed
+        mock_websession.post = _make_status_response(rt_enabled=False)
+        await home.update_real_time_consumption_enabled()
+
+        mock_websession.post = _make_status_response(rt_enabled=True)
+        await home.update_real_time_consumption_enabled()
+        assert home.has_real_time_consumption is True
+
+        # Long after the original timer would have expired, a brand new False must get a full
+        # fresh grace period rather than flipping on the stale timer.
+        mock_websession.post = _make_status_response(rt_enabled=False)
+        frozen_clock.current = armed + past_grace
+        await home.update_real_time_consumption_enabled()
+        assert home.has_real_time_consumption is True
+
+        frozen_clock.current = armed + past_grace + past_grace
+        await home.update_real_time_consumption_enabled()
+        assert home.has_real_time_consumption is False
 
 
 @patch("tibber.home.RESUBSCRIBE_WAIT_TIME", 0)
@@ -754,7 +819,7 @@ async def test_rt_subscription_resubscribes_after_watchdog_reconnect(
     reconnects. When reconnect succeeds (instead of raising) the watchdog schedules
     a resubscribe, which brings up a fresh subscription that delivers data again.
     """
-    mock_websession.post = _make_enabled_response()
+    mock_websession.post = _make_status_response(rt_enabled=True)
 
     call_count = 0
     stop = asyncio.Event()
@@ -800,7 +865,7 @@ async def test_rt_subscribe_recovers_from_repeated_errors(
     resubscribe task, and the subscription ends up running once subscribe stops
     failing. The watchdog is kept idle with a long timeout.
     """
-    mock_websession.post = _make_enabled_response()
+    mock_websession.post = _make_status_response(rt_enabled=True)
 
     call_count = 0
     settled = asyncio.Event()
@@ -825,3 +890,370 @@ async def test_rt_subscribe_recovers_from_repeated_errors(
     assert mock_realtime.connect.await_count == 3
 
     home.rt_unsubscribe()
+
+
+@patch("tibber.home.RESUBSCRIBE_WAIT_TIME", 0)
+@patch("tibber.home.REAL_TIME_CONSUMPTION_DISABLED_GRACE", dt.timedelta(seconds=-1))
+async def test_rt_resubscribe_confirmed_disable_notifies_on_error(
+    home: tibber.TibberHome,
+    mock_realtime: MagicMock,
+    mock_websession: MagicMock,
+) -> None:
+    """A confirmed disable (False sustained past the grace period) must notify on_error and stop.
+
+    Only a status that has been False for the whole grace period may end the resubscribe loop,
+    and it must do so visibly. The grace period is patched to an already-elapsed duration
+    so two consecutive False readings (one per resubscribe cycle, driven by repeated
+    subscribe failures) are enough to confirm the disable.
+    """
+    call_count = 0
+
+    def make_response(rt_enabled: bool) -> MagicMock:
+        mock_response = MagicMock()
+        mock_response.status = 200
+        mock_response.content_type = "application/json"
+        mock_response.json = AsyncMock(
+            return_value={
+                "data": {
+                    "viewer": {
+                        "home": {
+                            "id": HOME_ID,
+                            "features": {"realTimeConsumptionEnabled": rt_enabled},
+                        },
+                    },
+                },
+            },
+        )
+        return mock_response
+
+    async def post_side_effect(*args: Any, **kwargs: Any) -> MagicMock:  # noqa: ARG001, ANN401
+        nonlocal call_count
+        call_count += 1
+        # Initial subscription reports real time consumption enabled; every resubscription
+        # status query afterwards reports it disabled.
+        return make_response(call_count <= 2)
+
+    mock_websession.post.side_effect = post_side_effect
+
+    async def subscribe_raises(*args: Any, **kwargs: Any) -> AsyncGenerator:  # noqa: ANN401, ARG001
+        raise WebsocketTransportError("transport error")
+        yield
+
+    mock_realtime.subscribe = subscribe_raises
+
+    disabled_error_seen = asyncio.Event()
+    caught: list[Exception] = []
+
+    def on_error(exc: Exception) -> None:
+        caught.append(exc)
+        if isinstance(exc, RealTimeConsumptionDisabledError):
+            disabled_error_seen.set()
+
+    await home.rt_subscribe(MagicMock(), on_error=on_error)
+    await asyncio.wait_for(disabled_error_seen.wait(), timeout=1.0)
+
+    assert home.has_real_time_consumption is False
+    assert isinstance(caught[-1], RealTimeConsumptionDisabledError)
+    assert not home.rt_subscription_running
+
+    home.rt_unsubscribe()
+
+
+@patch("tibber.home.RESUBSCRIBE_WAIT_TIME", 0)
+async def test_rt_resubscribe_recovers_from_degraded_status_payload(
+    home: tibber.TibberHome,
+    mock_realtime: MagicMock,
+    mock_websession: MagicMock,
+) -> None:
+    """A degraded status-query payload during resubscribe must not disable a running home.
+
+    If a status query comes back with a well-formed 200 response whose payload carries
+    no usable `realTimeConsumptionEnabled` value, that must
+    be a no-op, so the resubscribe still refreshes info and brings the subscription back up.
+    """
+    call_count = 0
+
+    async def post_side_effect(*args: Any, **kwargs: Any) -> MagicMock:  # noqa: ARG001, ANN401
+        nonlocal call_count
+        call_count += 1
+        mock_response = MagicMock()
+        mock_response.status = 200
+        mock_response.content_type = "application/json"
+        if call_count == 1:
+            # Initial status query: real time consumption enabled.
+            mock_response.json = AsyncMock(
+                return_value={
+                    "data": {
+                        "viewer": {
+                            "home": {
+                                "id": HOME_ID,
+                                "features": {"realTimeConsumptionEnabled": True},
+                            },
+                        },
+                    },
+                },
+            )
+        elif call_count == 3:
+            # Resubscription status query: degraded response, the home cannot be resolved.
+            mock_response.json = AsyncMock(return_value={"data": {"viewer": {"home": None}}})
+        else:
+            mock_response.json = AsyncMock(
+                return_value={
+                    "data": {
+                        "viewer": {
+                            "name": "n",
+                            "userId": "u",
+                            "homes": [],
+                            "websocketSubscriptionUrl": None,
+                        },
+                    },
+                },
+            )
+        return mock_response
+
+    mock_websession.post = AsyncMock(side_effect=post_side_effect)
+
+    subscribe_call_count = 0
+    subscribed_again = asyncio.Event()
+
+    async def subscribe(*args: Any, **kwargs: Any) -> AsyncGenerator[Any, None]:  # noqa: ANN401, ARG001
+        nonlocal subscribe_call_count
+        subscribe_call_count += 1
+        if subscribe_call_count == 1:
+            raise WebsocketTransportError("transport error")
+            yield
+        subscribed_again.set()
+        yield {"liveMeasurement": {}}
+        await asyncio.Event().wait()
+
+    mock_realtime.subscribe = subscribe
+
+    await home.rt_subscribe(MagicMock(), on_error=lambda exc: None)  # noqa: ARG005
+    await asyncio.wait_for(subscribed_again.wait(), timeout=1.0)
+
+    assert home.has_real_time_consumption is True
+    assert mock_websession.post.call_count == 4
+    assert home.rt_subscription_running
+
+    home.rt_unsubscribe()
+
+
+def _info_price_payload(rt_enabled: bool | None, *, with_features: bool = True) -> dict[str, Any]:
+    """Return an UPDATE_INFO_PRICE payload reporting the given real time consumption status."""
+    home_payload: dict[str, Any] = {
+        "id": HOME_ID,
+        "currentSubscription": {
+            "status": "running",
+            "priceInfo": {
+                "today": [{"startsAt": "2026-05-06T00:00:00+02:00", "total": 1.0}],
+                "tomorrow": [],
+            },
+        },
+    }
+    if with_features:
+        home_payload["features"] = {"realTimeConsumptionEnabled": rt_enabled}
+    return {"data": {"viewer": {"home": home_payload}}}
+
+
+def _make_status_query_router(rt_enabled: bool) -> AsyncMock:
+    """Return a post mock reporting the given status, and a benign payload for every other query."""
+
+    def respond(*args: Any, **kwargs: Any) -> MagicMock:  # noqa: ANN401, ARG001
+        if kwargs["data"]["query"] == REAL_TIME_CONSUMPTION_ENABLED % HOME_ID:
+            return _json_response(_status_payload(rt_enabled))
+        return _json_response(
+            {
+                "data": {
+                    "viewer": {
+                        "name": "n",
+                        "userId": "u",
+                        "homes": [],
+                        "websocketSubscriptionUrl": None,
+                    },
+                },
+            },
+        )
+
+    return AsyncMock(side_effect=respond)
+
+
+@pytest.mark.parametrize("callback_raises", [False, True])
+@patch("tibber.home.RESUBSCRIBE_WAIT_TIME", 0)
+async def test_live_data_restarts_grace_period(
+    home: tibber.TibberHome,
+    mock_realtime: MagicMock,
+    mock_websession: MagicMock,
+    frozen_clock: type[FixedDateTime],
+    callback_raises: bool,
+) -> None:
+    """Live real time data must clear the suspected-disable timer.
+
+    Regression test: a False status arms the grace-period timer, the subscription then runs
+    healthily for hours, and a later brand new False status must get a full fresh grace period
+    instead of flipping the status immediately because of the hours-old timer.
+
+    Parametrized over a callback that raises, because the timer must be cleared before the
+    consumer callback runs: a consumer whose callback always throws must not accumulate a stale
+    suspicion while data is flowing.
+    """
+    armed = dt.datetime(2026, 5, 6, 0, 0, 0, tzinfo=dt.UTC)
+    # Every real time consumption status query reports disabled.
+    mock_websession.post = _make_status_query_router(rt_enabled=False)
+
+    subscribe_calls = 0
+    measurement_delivered = asyncio.Event()
+    resubscribed = asyncio.Event()
+    release = asyncio.Event()
+
+    async def subscribe(*args: Any, **kwargs: Any) -> AsyncGenerator[Any, None]:  # noqa: ANN401, ARG001
+        nonlocal subscribe_calls
+        subscribe_calls += 1
+        if subscribe_calls == 1:
+            yield {"liveMeasurement": {}}
+            # Stay up until the test simulates a transient transport error hours later.
+            await release.wait()
+            raise WebsocketTransportError("transport error")
+        resubscribed.set()
+        yield {"liveMeasurement": {}}
+        await asyncio.Event().wait()
+
+    mock_realtime.subscribe = subscribe
+
+    disabled_seen = asyncio.Event()
+
+    def on_error(exc: Exception) -> None:
+        if isinstance(exc, RealTimeConsumptionDisabledError):
+            disabled_seen.set()
+
+    def callback(_data: dict) -> None:
+        measurement_delivered.set()
+        if callback_raises:
+            raise ValueError("callback boom")
+
+    with patch("tibber.home.dt.datetime", frozen_clock):
+        frozen_clock.current = armed
+        await home.rt_subscribe(callback, on_error=on_error)
+        # The status query reported disabled, which only arms the timer, so the subscription
+        # still comes up and the first measurement clears the suspicion again.
+        await asyncio.wait_for(measurement_delivered.wait(), timeout=1.0)
+        assert home.has_real_time_consumption is True
+
+        # Two hours of healthy subscription pass, then a transient transport error resubscribes.
+        frozen_clock.current = armed + dt.timedelta(hours=2)
+        release.set()
+        pending = [
+            asyncio.create_task(resubscribed.wait()),
+            asyncio.create_task(disabled_seen.wait()),
+        ]
+        _, still_pending = await asyncio.wait(
+            pending,
+            timeout=1.0,
+            return_when=asyncio.FIRST_COMPLETED,
+        )
+        for task in still_pending:
+            task.cancel()
+
+    assert not disabled_seen.is_set(), "a brand new False must not confirm a disable on a stale timer"
+    assert home.has_real_time_consumption is True
+    assert resubscribed.is_set()
+    assert home.rt_subscription_running
+
+    home.rt_unsubscribe()
+
+
+async def test_update_info_false_status_keeps_true_within_grace(
+    home: tibber.TibberHome,
+    mock_websession: MagicMock,
+) -> None:
+    """A False status from the info and price query must only arm the timer, and not lose prices."""
+    mock_websession.post = AsyncMock(return_value=_json_response(_info_price_payload(rt_enabled=False)))
+
+    await home.update_info_and_price_info()
+
+    assert home.has_real_time_consumption is True
+    assert home.price_total == {"2026-05-06T00:00:00+02:00": 1.0}
+
+
+async def test_update_info_malformed_status_is_a_no_op(
+    home: tibber.TibberHome,
+    mock_websession: MagicMock,
+) -> None:
+    """An info and price payload without a usable status must not change the last known status."""
+    mock_websession.post = AsyncMock(
+        return_value=_json_response(_info_price_payload(None, with_features=False)),
+    )
+
+    await home.update_info_and_price_info()
+
+    assert home.has_real_time_consumption is True
+    assert home.price_total == {"2026-05-06T00:00:00+02:00": 1.0}
+
+
+@patch("tibber.home.RESUBSCRIBE_WAIT_TIME", 0)
+async def test_live_data_restarts_grace_period_armed_by_price_poll(
+    home: tibber.TibberHome,
+    mock_realtime: MagicMock,
+    mock_websession: MagicMock,
+    frozen_clock: type[FixedDateTime],
+) -> None:
+    """A timer armed by a periodic info and price poll must also be cleared by live data.
+
+    This is the shape a consumer normally hits in production: it polls prices on a
+    timer while the real time subscription runs, so a transient False can arm the grace-period
+    timer without any resubscribe happening at all.
+    """
+    armed = dt.datetime(2026, 5, 6, 0, 0, 0, tzinfo=dt.UTC)
+    mock_websession.post = _make_status_query_router(rt_enabled=True)
+
+    measurements: asyncio.Queue[Any] = asyncio.Queue()
+    gate = asyncio.Event()
+
+    async def subscribe(*args: Any, **kwargs: Any) -> AsyncGenerator[Any, None]:  # noqa: ANN401, ARG001
+        yield {"liveMeasurement": {}}
+        await gate.wait()
+        yield {"liveMeasurement": {}}
+        await asyncio.Event().wait()
+
+    mock_realtime.subscribe = subscribe
+
+    with patch("tibber.home.dt.datetime", frozen_clock):
+        frozen_clock.current = armed
+        await home.rt_subscribe(measurements.put_nowait)
+        await asyncio.wait_for(measurements.get(), timeout=1.0)
+
+        # A price poll reports real time consumption disabled, arming the grace-period timer.
+        mock_websession.post = AsyncMock(return_value=_json_response(_info_price_payload(rt_enabled=False)))
+        await home.update_info_and_price_info()
+        assert home.has_real_time_consumption is True
+
+        # The subscription is still healthy and delivers another measurement, clearing the timer.
+        gate.set()
+        await asyncio.wait_for(measurements.get(), timeout=1.0)
+
+        # Hours later another transient False must start a fresh grace period, not flip.
+        frozen_clock.current = armed + dt.timedelta(hours=2)
+        await home.update_info_and_price_info()
+
+    assert home.has_real_time_consumption is True
+
+    home.rt_unsubscribe()
+
+
+async def test_rt_resubscribe_confirmed_disable_without_on_error_logs_and_stops(
+    tibber_connection: tibber.Tibber,
+    mock_realtime: MagicMock,
+    mock_websession: MagicMock,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A confirmed disable must stop the resubscribe loop without raising when no on_error is set."""
+    # A never-read status resolves a False directly, with no grace period.
+    fresh_home = tibber.TibberHome(HOME_ID, tibber_connection)
+    mock_websession.post = _make_status_response(rt_enabled=False)
+
+    with caplog.at_level(logging.INFO):
+        await fresh_home.rt_subscribe(MagicMock())
+
+    assert fresh_home.has_real_time_consumption is False
+    mock_realtime.connect.assert_not_awaited()
+    assert not fresh_home.rt_subscription_running
+    assert f"Home {HOME_ID} does not have real time consumption enabled" in caplog.text

--- a/test/test_tibber.py
+++ b/test/test_tibber.py
@@ -1,7 +1,6 @@
 """Tests for pyTibber."""
 
 import datetime as dt
-from typing import Self
 from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import aiohttp
@@ -10,6 +9,8 @@ import pytest
 import tibber
 from tibber.const import RESOLUTION_DAILY, RESOLUTION_HOURLY
 from tibber.exceptions import FatalHttpExceptionError, InvalidLoginError, NotForDemoUserError
+
+from .conftest import FixedDateTime
 
 
 @pytest.fixture
@@ -92,26 +93,6 @@ def updated_hourly_data() -> list[dict]:
             "cost": 0.7,
         },
     ]
-
-
-class FixedDateTime(dt.datetime):
-    """Controllable datetime for deterministic fetch intervals."""
-
-    current = dt.datetime(2026, 5, 6, 2, 30, 0, tzinfo=dt.UTC)
-
-    @classmethod
-    def now(cls, tz: dt.tzinfo | None = None) -> Self:
-        if tz is None:
-            return cls(
-                cls.current.year,
-                cls.current.month,
-                cls.current.day,
-                cls.current.hour,
-                cls.current.minute,
-                cls.current.second,
-                cls.current.microsecond,
-            )
-        return cls.fromtimestamp(cls.current.timestamp(), tz=tz)
 
 
 @pytest.mark.asyncio
@@ -261,9 +242,10 @@ async def test_fetch_consumption_data_merges_using_two_predefined_payloads(
     monkeypatch: pytest.MonkeyPatch,
     initial_hourly_data: list[dict],
     updated_hourly_data: list[dict],
+    frozen_clock: type[FixedDateTime],
 ) -> None:
     """Second fetch merges old and new values through public API."""
-    FixedDateTime.current = dt.datetime(2026, 5, 6, 2, 30, 0, tzinfo=dt.UTC)
+    frozen_clock.current = dt.datetime(2026, 5, 6, 2, 30, 0, tzinfo=dt.UTC)
     payloads = iter([initial_hourly_data, updated_hourly_data])
 
     async def mock_get_historic_data(
@@ -281,9 +263,9 @@ async def test_fetch_consumption_data_merges_using_two_predefined_payloads(
 
         monkeypatch.setattr(home, "get_historic_data", mock_get_historic_data)
 
-        with patch("tibber.home.dt.datetime", FixedDateTime):
+        with patch("tibber.home.dt.datetime", frozen_clock):
             await home.fetch_consumption_data()
-            FixedDateTime.current = dt.datetime(2026, 5, 6, 4, 30, 0, tzinfo=dt.UTC)
+            frozen_clock.current = dt.datetime(2026, 5, 6, 4, 30, 0, tzinfo=dt.UTC)
             await home.fetch_consumption_data()
 
         assert home.hourly_consumption_data == [
@@ -302,9 +284,10 @@ async def test_fetch_consumption_data_does_not_duplicate_overlapping_timestamp(
     monkeypatch: pytest.MonkeyPatch,
     initial_hourly_data: list[dict],
     updated_hourly_data: list[dict],
+    frozen_clock: type[FixedDateTime],
 ) -> None:
     """Overlapping hour should be replaced, not duplicated."""
-    FixedDateTime.current = dt.datetime(2026, 5, 6, 2, 15, 0, tzinfo=dt.UTC)
+    frozen_clock.current = dt.datetime(2026, 5, 6, 2, 15, 0, tzinfo=dt.UTC)
     payloads = iter([initial_hourly_data, updated_hourly_data])
 
     async def mock_get_historic_data(
@@ -322,9 +305,9 @@ async def test_fetch_consumption_data_does_not_duplicate_overlapping_timestamp(
 
         monkeypatch.setattr(home, "get_historic_data", mock_get_historic_data)
 
-        with patch("tibber.home.dt.datetime", FixedDateTime):
+        with patch("tibber.home.dt.datetime", frozen_clock):
             await home.fetch_consumption_data()
-            FixedDateTime.current = dt.datetime(2026, 5, 6, 4, 15, 0, tzinfo=dt.UTC)
+            frozen_clock.current = dt.datetime(2026, 5, 6, 4, 15, 0, tzinfo=dt.UTC)
             await home.fetch_consumption_data()
 
         merged_by_timestamp = {entry["from"]: entry for entry in home.hourly_consumption_data}

--- a/tibber/__init__.py
+++ b/tibber/__init__.py
@@ -15,6 +15,7 @@ from .data_api import TibberDataAPI
 from .exceptions import (
     FatalHttpExceptionError,
     InvalidLoginError,
+    RealTimeConsumptionDisabledError,
     RetryableHttpExceptionError,
     UserAgentMissingError,
 )
@@ -29,6 +30,7 @@ _LOGGER = logging.getLogger(__name__)
 __all__ = [
     "FatalHttpExceptionError",
     "InvalidLoginError",
+    "RealTimeConsumptionDisabledError",
     "RetryableHttpExceptionError",
     "Tibber",
     "TibberDataAPI",

--- a/tibber/exceptions.py
+++ b/tibber/exceptions.py
@@ -15,6 +15,15 @@ class SubscriptionFailedError(TibberError):
     """Exception raised when subscription fails."""
 
 
+class RealTimeConsumptionDisabledError(TibberError):
+    """Exception raised when a home is confirmed to have real time consumption disabled.
+
+    Passed to the `on_error` callback of `TibberHome.rt_subscribe`. This error is terminal: the
+    resubscribe loop has stopped and will not retry on its own. To resume, call `rt_subscribe`
+    again, from a separate task rather than directly from the callback, and rate limit the retries.
+    """
+
+
 class UserAgentMissingError(TibberError):
     """Exception raised when user agent is missing."""
 

--- a/tibber/home.py
+++ b/tibber/home.py
@@ -15,7 +15,13 @@ import aiohttp
 from gql import gql
 
 from .const import RESOLUTION_DAILY, RESOLUTION_HOURLY, RESOLUTION_MONTHLY, RESOLUTION_WEEKLY
-from .exceptions import HttpExceptionError, SubscriptionFailedError, WebsocketReconnectedError, WebsocketTransportError
+from .exceptions import (
+    HttpExceptionError,
+    RealTimeConsumptionDisabledError,
+    SubscriptionFailedError,
+    WebsocketReconnectedError,
+    WebsocketTransportError,
+)
 from .gql_queries import (
     HISTORIC_DATA,
     HISTORIC_DATA_DATE,
@@ -36,6 +42,7 @@ MIN_IN_HOUR: int = 60
 MIN_IN_QUARTER: int = 15
 RT_SUBSCRIPTION_TIMEOUT = 60
 RESUBSCRIBE_WAIT_TIME = 60
+REAL_TIME_CONSUMPTION_DISABLED_GRACE = dt.timedelta(hours=1)
 
 MIN_REQUESTED_CONSUMPTION_HOURS: int = 3
 
@@ -281,31 +288,46 @@ class TibberHome:
     def _extract_real_time_consumption_enabled(data: dict[str, Any]) -> bool | None:
         """Safely extract the real time consumption enabled flag from an info payload."""
         try:
-            return data["viewer"]["home"]["features"]["realTimeConsumptionEnabled"]
+            value = data["viewer"]["home"]["features"]["realTimeConsumptionEnabled"]
         except (KeyError, TypeError):
             return None
+        # Anything but a bool carries no usable information, treat it like a malformed payload.
+        return value if isinstance(value, bool) else None
 
     def _update_has_real_time_consumption(self, enabled: bool | None) -> None:
-        _has_real_time_consumption = enabled
-        if self._has_real_time_consumption is None:
-            self._has_real_time_consumption = _has_real_time_consumption
+        """Update the believed real time consumption status from a single reading.
+
+        `enabled` is None when the reading carried no usable information (a malformed or
+        degraded API payload) and must not change the believed status at all.
+
+        A `False` reading following a known `True` does not immediately flip the status: it only
+        arms a grace-period timer and the home keeps reporting its last known `True`, so a single
+        bad or transiently-correct reading during a Tibber-side outage cannot strand the real time
+        subscription. The status flips to `False` only when a later `False` reading arrives more
+        than REAL_TIME_CONSUMPTION_DISABLED_GRACE after the timer was armed. Both a `True` reading
+        and incoming real time data (see `_handle_subscription_data`) clear the timer, so the grace
+        period always measures the time since the last evidence that real time consumption works.
+        """
+        if enabled is None:
             return
 
-        if self._has_real_time_consumption is True and _has_real_time_consumption is False:
-            now = dt.datetime.now(tz=dt.UTC)
-            if self._real_time_consumption_suggested_disabled is None:
-                self._real_time_consumption_suggested_disabled = now
-                self._has_real_time_consumption = None
-            elif now - self._real_time_consumption_suggested_disabled > dt.timedelta(hours=1):
-                self._real_time_consumption_suggested_disabled = None
-                self._has_real_time_consumption = False
-            else:
-                self._has_real_time_consumption = None
-            return
-
-        if _has_real_time_consumption is True:
+        if enabled is True:
             self._real_time_consumption_suggested_disabled = None
-        self._has_real_time_consumption = _has_real_time_consumption
+            self._has_real_time_consumption = True
+            return
+
+        # enabled is False from here on.
+        if self._has_real_time_consumption is not True:
+            self._real_time_consumption_suggested_disabled = None
+            self._has_real_time_consumption = False
+            return
+
+        now = dt.datetime.now(tz=dt.UTC)
+        if self._real_time_consumption_suggested_disabled is None:
+            self._real_time_consumption_suggested_disabled = now
+        elif now - self._real_time_consumption_suggested_disabled > REAL_TIME_CONSUMPTION_DISABLED_GRACE:
+            self._real_time_consumption_suggested_disabled = None
+            self._has_real_time_consumption = False
 
     @property
     def home_id(self) -> str:
@@ -432,7 +454,11 @@ class TibberHome:
         """Connect to Tibber and subscribe to Tibber real time subscription.
 
         :param callback: The function to call when data is received.
-        :param on_error: The function to call when an error occurs.
+        :param on_error: The function to call when an error occurs. Most errors are transient and
+            resubscription continues automatically, but a `RealTimeConsumptionDisabledError` is
+            terminal: the resubscribe loop has stopped and will not retry on its own. To resume,
+            call `rt_subscribe` again, from a separate task rather than directly from this
+            callback, and rate limit the retries.
         """
         if self._rt_listener is not None:
             raise RuntimeError("Already subscribed to real time data, call rt_unsubscribe first")
@@ -486,9 +512,17 @@ class TibberHome:
         """Handle incoming real time subscription data.
 
         Record that data was received to keep the subscription timeout watchdog
-        from treating a healthy, active subscription as unresponsive.
+        from treating a healthy, active subscription as unresponsive, and clear any suspected
+        real time consumption disable: a live measurement proves real time consumption is working
+        right now, and it is the only such proof available while a subscription runs healthily.
         """
         self._last_rt_data_received = time.time()
+        if self._real_time_consumption_suggested_disabled is not None:
+            _LOGGER.debug(
+                "Real time data received for home %s, clearing suspected real time consumption disable",
+                self.home_id,
+            )
+            self._real_time_consumption_suggested_disabled = None
         data = {"data": _data}
         try:
             data = self._add_extra_data(data)
@@ -572,8 +606,14 @@ class TibberHome:
             self.update_real_time_consumption_enabled(),
             "Failed to refresh real time consumption status, keeping last known status",
         )
-        if not self.has_real_time_consumption:
+        if self.has_real_time_consumption is False:
             _LOGGER.info("Home %s does not have real time consumption enabled", self.home_id)
+            if (on_error := self._rt_on_error) is not None:
+                on_error(
+                    RealTimeConsumptionDisabledError(
+                        f"Home {self.home_id} does not have real time consumption enabled",
+                    ),
+                )
             return
 
         # Update info to set websocket subscription url


### PR DESCRIPTION
### The problem

Tibber's API sometimes reports `realTimeConsumptionEnabled: false` for a home that actually has it enabled, typically during an outage on their side. We already had a one hour grace period that was supposed to wait this out before believing the home is disabled.

That grace period never worked. The first false reading set the status to "unknown", and the code that decides whether to keep resubscribing treated "unknown" the same as "disabled", so it stopped resubscribing immediately and silently. One bad reading was enough to take the real time subscription down until the whole integration was reloaded. I experienced this during an outage on 2026-09-02 and used the captured log to pin down the chain of events with the help of Claude.

### The fix

The status now follows clearer rules:

- A reading we can't make sense of (malformed or degraded payload) changes nothing at all.
- A false after a known true doesn't flip anything. It starts a one hour timer, and the home keeps reporting its last known true so the subscription stays up.
- The status only flips to false when a false reading arrives more than an hour after that timer started.
- Both a true reading and any incoming real time data clear the timer. Live measurements are proof that real time consumption works, and while a subscription is healthy they're the only signal we get.

When a disable is genuinely confirmed, the resubscribe loop stops and calls `on_error` with a new `RealTimeConsumptionDisabledError`, so consumers can see why it stopped instead of the subscription just going quiet.

### Things to note

`RealTimeConsumptionDisabledError` is terminal. The resubscribe loop has stopped and won't retry on its own. To resume, call `rt_subscribe` again, and do it from a separate task rather than directly from the callback, with some rate limiting. Retrying straight from `on_error` can spin, because a failed or degraded status refresh leaves the old false in place and the error fires again after a single request.

`has_real_time_consumption` means something slightly different now. None only means "never successfully read". It's no longer used for "we're unsure right now", so it should be much rarer. A home that is genuinely disabled now keeps its subscription alive up to an hour longer than before, which is the intended trade.

Home Assistant is unaffected for now. It calls `rt_subscribe` without `on_error`, so the new exception only shows up as an info log there until it opts in.

A shared frozen clock fixture moved to a new test/conftest.py and replaced the negative timedelta trick, which lets the one hour boundary be tested honestly.
